### PR TITLE
corrected chef-handler cookbook location

### DIFF
--- a/includes/includes_chef_handler_distribute.rst
+++ b/includes/includes_chef_handler_distribute.rst
@@ -1,5 +1,5 @@
 .. The contents of this file are included in multiple topics.
 .. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
 
-A handler can be distributed using a specific cookbook that is provided by |opscode| to help facilitate the distribution of custom |chef| handlers. The ``chef_handler`` cookbook exposes a lightweight resource provider that can be used to enable custom handlers from within recipes and is useful when including product-specific handlers in cookbooks. The ``chef_hander`` cookbook can be accessed here: https://github.com/someara/chef_handler-cookbook. See the README.md of the ``chef_handler`` cookbook for additional information.
+A handler can be distributed using a specific cookbook that is provided by |opscode| to help facilitate the distribution of custom |chef| handlers. The ``chef_handler`` cookbook exposes a lightweight resource provider that can be used to enable custom handlers from within recipes and is useful when including product-specific handlers in cookbooks. The ``chef_hander`` cookbook can be accessed here: http://community.opscode.com/chef_handler. See the README.md of the ``chef_handler`` cookbook for additional information.
 


### PR DESCRIPTION
Use the cookbook from the community site vs Sean's github fork.
