### PR TITLE
Fixed some 'knife cookbook site install' process

### DIFF
--- a/includes_knife/includes_knife_site_cookbook_install.rst
+++ b/includes_knife/includes_knife_site_cookbook_install.rst
@@ -3,12 +3,12 @@
 .. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
 
 
-The ``install`` argument is used to install a cookbook that has been downloaded from the community site to a local repository . This action uses the |git| version control system in conjunction with the |url cookbook| site to install community-contributed cookbooks to the local repository. Using this argument does the following:
+The ``install`` argument is used to install a cookbook that has been downloaded from the community site to a local git repository . This action uses the |git| version control system in conjunction with the |url cookbook| site to install community-contributed cookbooks to the local repository. Using this argument does the following:
 
   #. A new "pristine copy" branch is created in |git| for tracking the upstream.
-  #. All existing cookbooks are removed from the branch.
+  #. All existing versions of the cookbook are removed from the branch.
   #. The cookbook is downloaded from |url cookbook| in the |tar gz| format.
-  #. The downloaded cookbook is untarred and its contents are committed to |git|.
+  #. The downloaded cookbook is untarred and its contents are committed to |git| and a tag is created.
   #. The "pristine copy" branch is merged into the master branch.
   
 This process allows the upstream cookbook in the master branch to be modified while letting |git| maintain changes as a separate patch. When an updated upstream version becomes available, those changes can be merged while maintaining any local modifications.


### PR DESCRIPTION
`knife cookbook site install my_cookbook` won't remove all the existing cookbooks, only the existing version of my_cookbook, which is still available via a git tag.
