### PR TITLE
CHEF-2641 changed --no-editor to --disable-editing.

### DIFF
--- a/docs_reference_knife/source/index.rst
+++ b/docs_reference_knife/source/index.rst
@@ -15,7 +15,7 @@ Working with Knife
 
 JSON Data Format
 -----------------------------------------------------
-All data is entered using a text editor in |json| format, unless the ``--no-editor`` option is entered as part of a command. JSON is a common, language-independent data format that provides a simple text representation of arbitrary data structures. For more information about JSON, see http://www.json.org/ or http://en.wikipedia.org/wiki/JSON.
+All data is entered using a text editor in |json| format, unless the ``--disable-editing`` option is entered as part of a command. JSON is a common, language-independent data format that provides a simple text representation of arbitrary data structures. For more information about JSON, see http://www.json.org/ or http://en.wikipedia.org/wiki/JSON.
 
 Using Quotes
 -----------------------------------------------------
@@ -59,6 +59,8 @@ The following options can be run with all |knife| sub-commands:
      - |color|
    * - ``--defaults``
      - |defaults|
+   * - ``-d``, ``--disable-editing``
+     - |disable-editing|
    * - ``-e EDITOR``, ``--editor EDITOR``
      - |editor|
    * - ``-E ENVIRONMENT``, ``--environment ENVIRONMENT``
@@ -71,8 +73,6 @@ The following options can be run with all |knife| sub-commands:
      - |key|
    * - ``--no-color``
      - |no-color|
-   * - ``-n``, ``--no-editor``
-     - |no-editor|
    * - ``--print-after``
      - |print-after|
    * - ``-s URL``, ``--server-url URL``

--- a/man_knife_all/source/index.rst
+++ b/man_knife_all/source/index.rst
@@ -16,7 +16,7 @@ Working with Knife
 
 JSON Data Format
 -----------------------------------------------------
-All data is entered using a text editor in |json| format, unless the ``--no-editor`` option is entered as part of a command. JSON is a common, language-independent data format that provides a simple text representation of arbitrary data structures. For more information about JSON, see http://www.json.org/ or http://en.wikipedia.org/wiki/JSON.
+All data is entered using a text editor in |json| format, unless the ``--disable-editing`` option is entered as part of a command. JSON is a common, language-independent data format that provides a simple text representation of arbitrary data structures. For more information about JSON, see http://www.json.org/ or http://en.wikipedia.org/wiki/JSON.
 
 Using Quotes
 -----------------------------------------------------
@@ -57,6 +57,9 @@ The following options can be run with all |knife| sub-commands:
 ``--defaults``
    |defaults|
 
+``-d``, ``--disable-editing``
+   |disable-editing|
+
 ``-e EDITOR``, ``--editor EDITOR``
    |editor|
 
@@ -74,9 +77,6 @@ The following options can be run with all |knife| sub-commands:
 
 ``--no-color``
    |no-color|
-
-``-n``, ``--no-editor``
-   |no-editor|
 
 ``--print-after``
    |print-after|

--- a/man_knife_overview/source/index.rst
+++ b/man_knife_overview/source/index.rst
@@ -13,7 +13,7 @@ Working with Knife
 
 JSON Data Format
 -----------------------------------------------------
-All data is entered using a text editor in |json| format, unless the ``--no-editor`` option is entered as part of a command. JSON is a common, language-independent data format that provides a simple text representation of arbitrary data structures. For more information about JSON, see http://www.json.org/ or http://en.wikipedia.org/wiki/JSON.
+All data is entered using a text editor in |json| format, unless the ``--disable-editing`` option is entered as part of a command. JSON is a common, language-independent data format that provides a simple text representation of arbitrary data structures. For more information about JSON, see http://www.json.org/ or http://en.wikipedia.org/wiki/JSON.
 
 Using Quotes
 -----------------------------------------------------
@@ -54,6 +54,9 @@ The following options can be run with all |knife| sub-commands:
 ``--defaults``
    |defaults|
 
+``-d``, ``--disable-editing``
+   |disable-editing|
+
 ``-e EDITOR``, ``--editor EDITOR``
    |editor|
 
@@ -71,9 +74,6 @@ The following options can be run with all |knife| sub-commands:
 
 ``--no-color``
    |no-color|
-
-``-n``, ``--no-editor``
-   |no-editor|
 
 ``--print-after``
    |print-after|

--- a/swaps/swap_descriptions.txt
+++ b/swaps/swap_descriptions.txt
@@ -6,7 +6,7 @@
 
 
 .. A -- EDITED
-.. 
+..
 
 .. |admin client| replace:: Indicates that a client will be created as an admin client. This is required when users of |chef open server| need to access the API as an administrator.
 .. |after| replace:: Use this to add the run list item after the specified run list item.
@@ -77,6 +77,7 @@
 .. |description environment| replace:: The description of the environment. This value will populate the description field for the environment on the |chef server|.
 .. |dir| replace:: The directory into which a cookbook will be downloaded.
 .. |disable-bootstrap| replace:: Indicates that the bootstrap process should be disabled.
+.. |disable-editing| replace:: Indicates that |chef editor| will not be opened; data will be accepted as-is.
 .. |distro| replace:: Indicates that a bootstrap operation will use a template file. If this option is used the name of the template file (``--template-file``) must also be provided. The following distributions are supported: ``chef-full`` (the default bootstrap), ``centos5-gems``, ``fedora13-gems``, ``ubuntu10.04-gems``, ``ubuntu10.04-apt``, and ``ubuntu12.04-gems``.
 
 
@@ -237,7 +238,6 @@
 
 .. |network| replace:: The name of the network in which the virtual machine will be created.
 .. |no-color| replace:: Indicates that color will not be used in the output.
-.. |no-editor| replace:: Indicates that |chef editor| will not be opened; data will be accepted as-is.
 .. |no name tags| replace:: Indicates that tag names will not be displayed in the output.
 .. |[no-]host-key-verify| replace:: Use ``--no-host-key-verify`` to disable host key verification. Host key verification is enabled by default.
 .. |node-name| replace:: The name of the node on the |chef server|.


### PR DESCRIPTION
In order to work around a bug in the underlying option parser, we
changed --no-editor to --disable-editing.  This change should be
reflected in the documentation.
