### PR TITLE
Typos and knife tag

### DIFF
--- a/includes/includes_chef_search_environment.rst
+++ b/includes/includes_chef_search_environment.rst
@@ -11,6 +11,6 @@ Or, to include the same search in a recipe, use a code block similar to::
 
    qa_nodes = search(:node,"chef_environment:QA")      
    qa_nodes.each do |qa_node|                          
-       # Do useful specific to qa nodes only
+       # Do useful work specific to qa nodes only
    end
 

--- a/includes_knife/includes_knife_tag_list.rst
+++ b/includes_knife/includes_knife_tag_list.rst
@@ -3,7 +3,7 @@
 .. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
 
 
-The ``list`` argument is used to list all of the tags that have been applied to one or more nodes. 
+The ``list`` argument is used to list all of the tags that have been applied to a node.
 
 This argument has the following syntax::
 
@@ -16,9 +16,3 @@ For example, to view the tags for a single node, enter:
 .. code-block:: bash
 
    $ knife tag list node
-
-To view tags for more than one node, just specify the additional nodes:
-
-.. code-block:: bash
-
-   $ knife tag list node1 node2 node3

--- a/swaps/swap_names.txt
+++ b/swaps/swap_names.txt
@@ -434,7 +434,7 @@
 
 .. |url chef repo| replace:: https://github.com/opscode/chef-repo
 .. |url community| replace:: community.opscode.com
-.. |url cookbook| replace:: cookbooks.opscode.com
-.. |url cookbook rest api| replace:: cookbooks.opscode.com/api/v1/
+.. |url cookbook| replace:: https://cookbooks.opscode.com
+.. |url cookbook rest api| replace:: https://cookbooks.opscode.com/api/v1/
                             
 


### PR DESCRIPTION
1. Typos
2. knife tag cannot handle the specification of multiple nodes now.
   If we give it node1 node2 node3, only node1's tags are shown. That is true even at 10.16.0.rc.1, which is the most current.
