### PR TITLE
Resource example code cleanup 

### DIFF
--- a/steps/step_chef_resource_cookbook_file_transfer_a_file.rst
+++ b/steps/step_chef_resource_cookbook_file_transfer_a_file.rst
@@ -6,5 +6,5 @@ To transfer a file in a cookbook:
 
    cookbook_file "/tmp/testfile" do
      source "testfile" # this is the value that would be inferred from the path parameter
-     mode "0644"
+     mode 00644
    end

--- a/steps/step_chef_resource_deploy_add_private_key_from_data_bag.rst
+++ b/steps/step_chef_resource_deploy_add_private_key_from_data_bag.rst
@@ -22,5 +22,5 @@ Remember to convert new lines in the private key to \n when copying it to the da
    file "/tmp/private_code/.ssh/id_deploy" do
      content app['deploy_key']
      owner "ubuntu"
-     mode 0600
+     mode 00600
    end

--- a/steps/step_chef_resource_deploy_add_private_key_from_recipe.rst
+++ b/steps/step_chef_resource_deploy_add_private_key_from_recipe.rst
@@ -9,7 +9,7 @@ To add a private key to a node:
    cookbook_file "/tmp/private_code/.ssh/id_deploy" do
      source "id_deploy"
      owner "ubuntu"
-     mode 0600
+     mode 00600
    end
 
 After this has been added to a recipe, it should be able to deploy the private repository.

--- a/steps/step_chef_resource_deploy_embedded_recipes_for_callbacks.rst
+++ b/steps/step_chef_resource_deploy_embedded_recipes_for_callbacks.rst
@@ -5,8 +5,8 @@ Using resources from within your callbacks as blocks or within callback files di
 
 .. code-block:: ruby
 
-   deploy "#{node[:tmpdir]}/deploy" do
-     repo "#{node[:tmpdir]}/gitrepo/typo/"
+   deploy "#{node['tmpdir']}/deploy" do
+     repo "#{node['tmpdir']}/gitrepo/typo/"
      environment "RAILS_ENV" => "production"
      revision "HEAD"
      action :deploy
@@ -18,13 +18,13 @@ Using resources from within your callbacks as blocks or within callback files di
        current_release = release_path
        
        directory "#{current_release}/deploy" do
-         mode "0755"
+         mode 00755
        end
      
        # creates a callback for before_symlink
        template "#{current_release}/deploy/before_symlink_callback.rb" do
          source "embedded_recipe_before_symlink.rb.erb"
-         mode "0644"
+         mode 00644
        end
       
      end
@@ -35,7 +35,7 @@ Using resources from within your callbacks as blocks or within callback files di
      restart do
        current_release = release_path
        file "#{release_path}/tmp/restart.txt" do
-         mode "0644"
+         mode 00644
        end
      end
    

--- a/steps/step_chef_resource_deploy_recipe_uses_ssh_wrapper.rst
+++ b/steps/step_chef_resource_deploy_recipe_uses_ssh_wrapper.rst
@@ -22,7 +22,7 @@ To write a recipe that uses an SSH wrapper:
       cookbook_file "/tmp/private_code/wrap-ssh4git.sh" do
         source "wrap-ssh4git.sh"
         owner "ubuntu"
-        mode 0700
+        mode 00700
       end
       
       deploy "private_repo" do

--- a/steps/step_chef_resource_directory_create.rst
+++ b/steps/step_chef_resource_directory_create.rst
@@ -7,6 +7,6 @@ To create a directory:
    directory "/tmp/something" do
      owner "root"
      group "root"
-     mode "0755"
+     mode 00755
      action :create
    end

--- a/steps/step_chef_resource_directory_create_recursively.rst
+++ b/steps/step_chef_resource_directory_create_recursively.rst
@@ -6,7 +6,7 @@ To create a directory recursively:
 
    %w{dir1 dir2 dir3}.each do |dir|
      directory "/tmp/mydirs/#{dir}" do
-       mode "0775"
+       mode 00775
        owner "root"
        group "root"
        action :create

--- a/steps/step_chef_resource_execute_command_upon_notification.rst
+++ b/steps/step_chef_resource_execute_command_upon_notification.rst
@@ -12,5 +12,5 @@ To execute a command only upon notification:
    
    template "/tmp/something.ldif" do
      source "something.ldif"
-     notifies :run, resources(:execute => "slapadd")
+     notifies :run, "execute[slapadd]"
    end

--- a/steps/step_chef_resource_file_create.rst
+++ b/steps/step_chef_resource_file_create.rst
@@ -7,6 +7,6 @@ To create a file:
    file "/tmp/something" do
      owner "root"
      group "root"
-     mode "0755"
+     mode 00755
      action :create
    end

--- a/steps/step_chef_resource_log_set_debug.rst
+++ b/steps/step_chef_resource_log_set_debug.rst
@@ -4,4 +4,6 @@ To set the debug logging level:
 
 .. code-block:: ruby
 
-   log("a debug string") { level :debug }
+   log "a debug string" do
+     level :debug
+   end

--- a/steps/step_chef_resource_ohai_reload_after_create_user.rst
+++ b/steps/step_chef_resource_ohai_reload_after_create_user.rst
@@ -13,13 +13,13 @@ To reload |ohai| configuration after a new user is created:
      home "/dev/null"
      shell "/sbin/nologin"
      system true
-     notifies :reload, resources(:ohai => "reload_passwd"), :immediately
+     notifies :reload, "ohai[reload_passwd]", :immediately
    end
    
    ruby_block "just an example" do
      block do
        # These variables will now have the new values
-       puts node[:etc][:passwd][:daemonuser][:uid]
-       puts node[:etc][:passwd][:daemonuser][:gid]
+       puts node['etc']['passwd']['daemonuser']['uid']
+       puts node['etc']['passwd']['daemonuser']['gid']
      end
    end

--- a/steps/step_chef_resource_remote_directory_recursive_transfer.rst
+++ b/steps/step_chef_resource_remote_directory_recursive_transfer.rst
@@ -10,9 +10,9 @@ To recursively transfer a directory from a remote location:
      files_backup 10
      files_owner "root"
      files_group "root"
-     files_mode "0644"
+     files_mode 00644
      owner "nobody"
      group "nobody"
-     mode "0755"
+     mode 00755
    end
 

--- a/steps/step_chef_resource_remote_file_transfer_from_url.rst
+++ b/steps/step_chef_resource_remote_file_transfer_from_url.rst
@@ -6,6 +6,6 @@ To transfer a file from a URL:
 
    remote_file "/tmp/testfile" do
      source "http://www.example.com/tempfiles/testfile"
-     mode "0644"
-     checksum "08da002l" # A SHA256 (or portion thereof) of the file.
+     mode 00644
+     checksum "3a7dac00b1" # A SHA256 (or portion thereof) of the file.
    end

--- a/steps/step_chef_resource_remote_file_transfer_remote_source_changes.rst
+++ b/steps/step_chef_resource_remote_file_transfer_remote_source_changes.rst
@@ -1,4 +1,4 @@
-.. This is an included how-to. 
+.. This is an included how-to.
 
 To transfer a file only if the remote source has changed (using the ``http_request`` resource):
 
@@ -8,13 +8,13 @@ To transfer a file only if the remote source has changed (using the ``http_reque
      source "http://couchdb.apache.org/img/sketch.png"
      action :nothing
    end
-   
+
    http_request "HEAD #{http://couchdb.apache.org/img/sketch.png}" do
      message ""
-     url http://couchdb.apache.org/img/sketch.png
+     url "http://couchdb.apache.org/img/sketch.png"
      action :head
      if File.exists?("/tmp/couch.png")
        headers "If-Modified-Since" => File.mtime("/tmp/couch.png").httpdate
      end
-     notifies :create, resources(:remote_file => "/tmp/couch.png"), :immediately
+     notifies :create, "remote_file[/tmp/couch.png]", :immediately
    end

--- a/steps/step_chef_resource_service_change_service_provider_based_on_node.rst
+++ b/steps/step_chef_resource_service_change_service_provider_based_on_node.rst
@@ -5,9 +5,9 @@ To change a service provider depending on a node's platform:
 .. code-block:: ruby
 
    service "example_service" do
-     case node[:platform]
+     case node["platform"]
      when "ubuntu"
-       if node[:platform_version].to_f >= 9.10
+       if node["platform_version"].to_f >= 9.10
          provider Chef::Provider::Service::Upstart
        end
      end

--- a/steps/step_chef_resource_service_manage_ssh_based_on_node_platform.rst
+++ b/steps/step_chef_resource_service_manage_ssh_based_on_node_platform.rst
@@ -5,7 +5,7 @@ To manage the |ssh| service, named depending on the platform of the node:
 .. code-block:: ruby
 
    service "example_service" do
-     case node[:platform]
+     case node["platform"]
      when "CentOS","RedHat","Fedora"
        service_name "redhat_name"
      else

--- a/steps/step_chef_resource_template_configure_file_with_variable_map.rst
+++ b/steps/step_chef_resource_template_configure_file_with_variable_map.rst
@@ -7,6 +7,6 @@ To configure a file from a template with a variable map:
    template "/tmp/config.conf" do
      source "config.conf.erb"
      variables(
-       :config_var => node[:configs][:config_var]
+       :config_var => node["configs"]["config_var"]
      )
    end

--- a/steps/step_chef_resource_yum_package_delete_repo_use_yum_to_scrub_cache.rst
+++ b/steps/step_chef_resource_yum_package_delete_repo_use_yum_to_scrub_cache.rst
@@ -11,8 +11,8 @@ To delete a repository while using |yum| to scrub the cache to avoid issues:
    
    file "/etc/yum.repos.d/bad.repo" do
      action :delete
-     notifies :run, resources(:execute => "clean-yum-cache"), :immediately
-     notifies :create, resources(:ruby_block => "reload-internal-yum-cache"), :immediately
+     notifies :run, "execute[clean-yum-cache]", :immediately
+     notifies :create, "ruby_block[reload-internal-yum-cache]", :immediately
    end
 
 .. note:: The previous two examples are thanks to gaffneyc @ https://gist.github.com/918711.

--- a/steps/step_chef_resource_yum_package_handle_cookbook_file_and_yum_package.rst
+++ b/steps/step_chef_resource_yum_package_handle_cookbook_file_and_yum_package.rst
@@ -7,10 +7,10 @@ When a ``cookbook_file`` resource and a ``yum_package`` resource are both called
 
    cookbook_file "/etc/yum.repos.d/custom.repo" do
      source "custom"
-     mode "0644"
+     mode 00644
    end
    
    yum_package "only-in-custom-repo" do
      action :install
-     flush_cache [ :before ]
+     flush_cache [:before]
    end

--- a/steps/step_chef_resource_yum_package_install_yum_repo_from_file.rst
+++ b/steps/step_chef_resource_yum_package_install_yum_repo_from_file.rst
@@ -18,7 +18,7 @@ To install new |yum| repositories from a file, where the installation of the rep
    
    cookbook_file "/etc/yum.repos.d/custom.repo" do
      source "custom"
-     mode "0644"
-     notifies :run, resources(:execute => "create-yum-cache"), :immediately
-     notifies :create, resources(:ruby_block => "reload-internal-yum-cache"), :immediately
+     mode 00644
+     notifies :run, "execute[create-yum-cache]", :immediately
+     notifies :create, "ruby_block[reload-internal-yum-cache]", :immediately
    end


### PR DESCRIPTION
- Use strings for node attributes
- Use octal modes except in string mode example
- Use simpler notifies syntax
