### PR TITLE
Add and use 2 new json dsl swaps

### DIFF
--- a/includes_environment/includes_environment_format_json.rst
+++ b/includes_environment/includes_environment_format_json.rst
@@ -30,7 +30,7 @@ The |json| format has two additional settings:
    * - Setting
      - Description
    * - ``chef_type``
-     - |json dsl chef type|
+     - |json dsl environment chef type|
    * - ``json_class``
-     - |json dsl json class|
+     - |json dsl environment json class|
 

--- a/includes_role/includes_role_formats_json.rst
+++ b/includes_role/includes_role_formats_json.rst
@@ -52,6 +52,6 @@ The JSON format has two additional settings:
    * - Setting
      - Description
    * - ``chef_type``
-     - |json dsl chef type|
+     - |json dsl role chef type|
    * - ``json_class``
-     - |json dsl json class|
+     - |json dsl role json class|

--- a/swaps/swap_desc_j.txt
+++ b/swaps/swap_desc_j.txt
@@ -8,6 +8,8 @@
 
 .. |json_attribs| replace:: Use to override attributes that are set from other locations, such as from within a cookbook or by a role. The value must be entered as JSON data.
 .. |json-attributes| replace:: A JSON string that is added to the first run of a |chef client|.
-.. |json dsl chef type| replace:: This should always be set to ``environment``. Use this setting for any custom process that consumes environment objects outside of |ruby|.
-.. |json dsl json class| replace:: This should always be set to ``Chef::Environment``. This setting is used internally by |chef| to auto-inflate an environment object. If objects are being rebuilt outside of |ruby|, ignore it.
+.. |json dsl role chef type| replace:: This should always be set to ``role``. Use this setting for any custom process that consumes role objects outside of |ruby|.
+.. |json dsl environment chef type| replace:: This should always be set to ``environment``. Use this setting for any custom process that consumes environment objects outside of |ruby|.
+.. |json dsl role json class| replace:: This should always be set to ``Chef::Role``. This setting is used internally by |chef| to auto-inflate an role object. If objects are being rebuilt outside of |ruby|, ignore it.
+.. |json dsl environment json class| replace:: This should always be set to ``Chef::Environment``. This setting is used internally by |chef| to auto-inflate an environment object. If objects are being rebuilt outside of |ruby|, ignore it.
 


### PR DESCRIPTION
- `json dsl environment chef type` replaces `json dsl chef type`
- `json dsl environment json class` replaces `json dsl json class`
- add `json dsl role chef type` and `json dsl role json class`
- Update the usage of the swaps

Thanks to Tom Ashley for sending the correction in to docs@opscode.com
