### PR TITLE
Add documentation for additional role endpoints

### DIFF
--- a/chef_master/source/api_chef_server.rst
+++ b/chef_master/source/api_chef_server.rst
@@ -60,6 +60,7 @@ The |api chef server| has the following endpoints:
 * :doc:`api_chef_server_nodes_name`
 * :doc:`api_chef_server_roles`
 * :doc:`api_chef_server_roles_name`
+* :doc:`api_chef_server_roles_name_environments`
 * :doc:`api_chef_server_sandboxes`
 * :doc:`api_chef_server_sandboxes_id`
 * :doc:`api_chef_server_search`
@@ -88,6 +89,7 @@ The |api chef server| has the following endpoints:
    api_chef_server_requirements
    api_chef_server_roles
    api_chef_server_roles_name
+   api_chef_server_roles_name_environments
    api_chef_server_sandboxes
    api_chef_server_sandboxes_id
    api_chef_server_search

--- a/chef_master/source/api_chef_server.rst
+++ b/chef_master/source/api_chef_server.rst
@@ -61,6 +61,7 @@ The |api chef server| has the following endpoints:
 * :doc:`api_chef_server_roles`
 * :doc:`api_chef_server_roles_name`
 * :doc:`api_chef_server_roles_name_environments`
+* :doc:`api_chef_server_roles_name_environments_name`
 * :doc:`api_chef_server_sandboxes`
 * :doc:`api_chef_server_sandboxes_id`
 * :doc:`api_chef_server_search`
@@ -90,6 +91,7 @@ The |api chef server| has the following endpoints:
    api_chef_server_roles
    api_chef_server_roles_name
    api_chef_server_roles_name_environments
+   api_chef_server_roles_name_environments_name
    api_chef_server_sandboxes
    api_chef_server_sandboxes_id
    api_chef_server_search

--- a/chef_master/source/api_chef_server_roles_name_environments.rst
+++ b/chef_master/source/api_chef_server_roles_name_environments.rst
@@ -1,0 +1,39 @@
+=====================================================
+/roles/NAME/environments
+=====================================================
+
+.. include:: ../../swaps/swap_desc_a.txt
+.. include:: ../../swaps/swap_desc_b.txt
+.. include:: ../../swaps/swap_desc_c.txt
+.. include:: ../../swaps/swap_desc_d.txt
+.. include:: ../../swaps/swap_desc_e.txt
+.. include:: ../../swaps/swap_desc_f.txt
+.. include:: ../../swaps/swap_desc_g.txt
+.. include:: ../../swaps/swap_desc_h.txt
+.. include:: ../../swaps/swap_desc_i.txt
+.. include:: ../../swaps/swap_desc_j.txt
+.. include:: ../../swaps/swap_desc_k.txt
+.. include:: ../../swaps/swap_desc_l.txt
+.. include:: ../../swaps/swap_desc_m.txt
+.. include:: ../../swaps/swap_desc_n.txt
+.. include:: ../../swaps/swap_desc_o.txt
+.. include:: ../../swaps/swap_desc_p.txt
+.. include:: ../../swaps/swap_desc_q.txt
+.. include:: ../../swaps/swap_desc_r.txt
+.. include:: ../../swaps/swap_desc_s.txt
+.. include:: ../../swaps/swap_desc_t.txt
+.. include:: ../../swaps/swap_desc_u.txt
+.. include:: ../../swaps/swap_desc_v.txt
+.. include:: ../../swaps/swap_desc_w.txt
+.. include:: ../../swaps/swap_desc_x.txt
+.. include:: ../../swaps/swap_desc_y.txt
+.. include:: ../../swaps/swap_desc_z.txt
+.. include:: ../../swaps/swap_http.txt
+.. include:: ../../swaps/swap_names.txt
+.. include:: ../../swaps/swap_notes.txt
+
+.. include:: ../../includes_api_chef_server/includes_api_chef_server_endpoint_role_name_environments.rst
+
+GET
+=====================================================
+.. include:: ../../includes_api_chef_server/includes_api_chef_server_endpoint_role_name_environments_get.rst

--- a/chef_master/source/api_chef_server_roles_name_environments_name.rst
+++ b/chef_master/source/api_chef_server_roles_name_environments_name.rst
@@ -1,0 +1,39 @@
+=====================================================
+/roles/NAME/environments/NAME
+=====================================================
+
+.. include:: ../../swaps/swap_desc_a.txt
+.. include:: ../../swaps/swap_desc_b.txt
+.. include:: ../../swaps/swap_desc_c.txt
+.. include:: ../../swaps/swap_desc_d.txt
+.. include:: ../../swaps/swap_desc_e.txt
+.. include:: ../../swaps/swap_desc_f.txt
+.. include:: ../../swaps/swap_desc_g.txt
+.. include:: ../../swaps/swap_desc_h.txt
+.. include:: ../../swaps/swap_desc_i.txt
+.. include:: ../../swaps/swap_desc_j.txt
+.. include:: ../../swaps/swap_desc_k.txt
+.. include:: ../../swaps/swap_desc_l.txt
+.. include:: ../../swaps/swap_desc_m.txt
+.. include:: ../../swaps/swap_desc_n.txt
+.. include:: ../../swaps/swap_desc_o.txt
+.. include:: ../../swaps/swap_desc_p.txt
+.. include:: ../../swaps/swap_desc_q.txt
+.. include:: ../../swaps/swap_desc_r.txt
+.. include:: ../../swaps/swap_desc_s.txt
+.. include:: ../../swaps/swap_desc_t.txt
+.. include:: ../../swaps/swap_desc_u.txt
+.. include:: ../../swaps/swap_desc_v.txt
+.. include:: ../../swaps/swap_desc_w.txt
+.. include:: ../../swaps/swap_desc_x.txt
+.. include:: ../../swaps/swap_desc_y.txt
+.. include:: ../../swaps/swap_desc_z.txt
+.. include:: ../../swaps/swap_http.txt
+.. include:: ../../swaps/swap_names.txt
+.. include:: ../../swaps/swap_notes.txt
+
+.. include:: ../../includes_api_chef_server/includes_api_chef_server_endpoint_role_name_environments_name.rst
+
+GET
+=====================================================
+.. include:: ../../includes_api_chef_server/includes_api_chef_server_endpoint_role_name_environments_name_get.rst

--- a/docs_all/source/chef_server_api.rst
+++ b/docs_all/source/chef_server_api.rst
@@ -292,6 +292,14 @@ GET
 -----------------------------------------------------
 .. include:: ../../includes_api_chef_server/includes_api_chef_server_endpoint_role_name_environments_get.rst
 
+/roles/NAME/environments/NAME
+=====================================================
+.. include:: ../../includes_api_chef_server/includes_api_chef_server_endpoint_role_name_environments_name.rst
+
+GET
+-----------------------------------------------------
+.. include:: ../../includes_api_chef_server/includes_api_chef_server_endpoint_role_name_environments_name_get.rst
+
 
 /sandboxes
 =====================================================

--- a/docs_all/source/chef_server_api.rst
+++ b/docs_all/source/chef_server_api.rst
@@ -284,6 +284,14 @@ PUT
 -----------------------------------------------------
 .. include:: ../../includes_api_chef_server/includes_api_chef_server_endpoint_role_name_put.rst
 
+/roles/NAME/environments
+=====================================================
+.. include:: ../../includes_api_chef_server/includes_api_chef_server_endpoint_role_name_environments.rst
+
+GET
+-----------------------------------------------------
+.. include:: ../../includes_api_chef_server/includes_api_chef_server_endpoint_role_name_environments_get.rst
+
 
 /sandboxes
 =====================================================

--- a/docs_reference_api_chef_server/source/chef_server_api.rst
+++ b/docs_reference_api_chef_server/source/chef_server_api.rst
@@ -282,6 +282,14 @@ PUT
 -----------------------------------------------------
 .. include:: ../../includes_api_chef_server/includes_api_chef_server_endpoint_role_name_put.rst
 
+/roles/NAME/environments
+=====================================================
+.. include:: .. ../../includes_api_chef_server/includes_api_chef_server_endpoint_role_name_environments.rst
+
+GET
+-----------------------------------------------------
+.. include:: .. ../../includes_api_chef_server/includes_api_chef_server_endpoint_role_name_environments_get.rst
+
 
 /sandboxes
 =====================================================

--- a/docs_reference_api_chef_server/source/chef_server_api.rst
+++ b/docs_reference_api_chef_server/source/chef_server_api.rst
@@ -290,6 +290,14 @@ GET
 -----------------------------------------------------
 .. include:: .. ../../includes_api_chef_server/includes_api_chef_server_endpoint_role_name_environments_get.rst
 
+/roles/NAME/environments/NAME
+=====================================================
+.. include:: .. ../../includes_api_chef_server/includes_api_chef_server_endpoint_role_name_environments_name.rst
+
+GET
+-----------------------------------------------------
+.. include:: .. ../../includes_api_chef_server/includes_api_chef_server_endpoint_role_name_environments_name_get.rst
+
 
 /sandboxes
 =====================================================

--- a/includes_api_chef_server/includes_api_chef_server_endpoint_role_name_environments.rst
+++ b/includes_api_chef_server/includes_api_chef_server_endpoint_role_name_environments.rst
@@ -1,0 +1,4 @@
+.. The contents of this file are included in multiple topics.
+.. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
+
+The /roles/NAME/environments endpoint has the following method: GET.

--- a/includes_api_chef_server/includes_api_chef_server_endpoint_role_name_environments_get.rst
+++ b/includes_api_chef_server/includes_api_chef_server_endpoint_role_name_environments_get.rst
@@ -1,0 +1,38 @@
+.. The contents of this file are included in multiple topics.
+.. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
+
+The GET method returns a list of the environments that have
+environment-specific run lists in the given role as |json|.
+
+This method has no parameters.
+
+**Request**
+
+.. code-block:: xml
+
+   GET /roles/NAME/environments
+
+**Response**
+
+The response will return something like the following:
+
+.. code-block:: javascript
+
+   ["_default","production","qa"]
+
+**Response Codes**
+
+.. list-table::
+   :widths: 200 300
+   :header-rows: 1
+
+   * - Response Code
+     - Description
+   * - ``200``
+     - |response code 200 ok|
+   * - ``401``
+     - |response code 401 unauthorized|
+   * - ``403``
+     - |response code 403 forbidden|
+   * - ``404``
+     - |response code 404 not found|

--- a/includes_api_chef_server/includes_api_chef_server_endpoint_role_name_environments_name.rst
+++ b/includes_api_chef_server/includes_api_chef_server_endpoint_role_name_environments_name.rst
@@ -1,0 +1,4 @@
+.. The contents of this file are included in multiple topics.
+.. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
+
+The /roles/NAME/environments/ENV_NAME endpoint has the following method: GET.

--- a/includes_api_chef_server/includes_api_chef_server_endpoint_role_name_environments_name_get.rst
+++ b/includes_api_chef_server/includes_api_chef_server_endpoint_role_name_environments_name_get.rst
@@ -1,0 +1,41 @@
+.. The contents of this file are included in multiple topics.
+.. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
+
+The GET method returns the named role's environment-specific run list
+for the named environment as |json|.
+
+This method has no parameters.
+
+**Request**
+
+.. code-block:: xml
+
+   GET /roles/NAME/environments/NAME
+
+where the first NAME is the name of the role and the second is the
+name of the environment.
+
+**Response**
+
+The response will return something like the following:
+
+.. code-block:: javascript
+
+    {"run_list":["recipe[foo]"]}
+
+**Response Codes**
+
+.. list-table::
+   :widths: 200 300
+   :header-rows: 1
+
+   * - Response Code
+     - Description
+   * - ``200``
+     - |response code 200 ok|
+   * - ``401``
+     - |response code 401 unauthorized|
+   * - ``403``
+     - |response code 403 forbidden|
+   * - ``404``
+     - |response code 404 not found|


### PR DESCRIPTION
This adds documentation for the following two role endpoints:

```
/roles/NAME/environments
/roles/NAME/environments/NAME
```

both of which deal with environment-specific run lists within roles.  Both endpoints support the GET method.  The endpoints are present in both Chef 10 and Chef 11.
