### PR TITLE
Make the expected template file's extension more explicit to bluepill newcomers

### DIFF
--- a/step_lwrp/step_lwrp_bluepill_service_use_resource_template.rst
+++ b/step_lwrp/step_lwrp_bluepill_service_use_resource_template.rst
@@ -4,7 +4,7 @@ To use the ``template`` resource in a recipe:
 
 .. code-block:: ruby
 
-   template "/etc/bluepill/my_app" do
+   template "/etc/bluepill/my_app.pill" do
      source "my_app.pill.erb"
    end
    my_app.pill.erb


### PR DESCRIPTION
The wiki and README file for the bluepill recipe both display the destination file name with .pill.
This brings the docs page in line with them.
