### PR TITLE
Correct directory structure of the omnibus chef installation.

### DIFF
--- a/step_install/step_install_workstation_omnibus.rst
+++ b/step_install/step_install_workstation_omnibus.rst
@@ -37,7 +37,7 @@ To run the |omnibus installer|:
 #. After |chef| has been installed, the following folder structure will be present on the local machine::
 
       /opt
-         /opscode
+         /chef
             /bin
             /embedded
                /bin


### PR DESCRIPTION
The omnibus installer now installs chef to /opt/chef rather
than /opt/opscode.
