### PR TITLE
Definition syntax fix

### DIFF
--- a/includes_cookbooks/includes_cookbooks_definition_syntax.rst
+++ b/includes_cookbooks/includes_cookbooks_definition_syntax.rst
@@ -22,7 +22,7 @@ For example, a definition named ``apache_site`` with an parameter called ``actio
 .. code-block:: ruby
 
    define :apache_site, :action => :enable do
-     if params[:enable]
+     if params[:action] == :enable
         ...
      else
         ...

--- a/includes_cookbooks/includes_cookbooks_definition_syntax.rst
+++ b/includes_cookbooks/includes_cookbooks_definition_syntax.rst
@@ -17,7 +17,7 @@ The basic syntax of a definition:
      params_hash
    end
 
-For example, a definition named ``apache_site`` with an parameter called ``action`` with an argument for ``enable do`` would look something like:
+For example, a definition named ``apache_site`` with an parameter called ``action`` with an argument for ``enable`` would look something like:
 
 .. code-block:: ruby
 


### PR DESCRIPTION
Couple of small fixes to the definitions syntax:
- remove a `do` that was present in the definition argument
- update the example definition to have valid syntax, the current example was checking for a value of `params[:enable]` but this isn't what would be passed in, you would have `params[:action]` which would then contain a value of `:enable` (or whatever you've set it to be).
