### PR TITLE
Typo in definition syntax

### DIFF
--- a/includes_cookbooks/includes_cookbooks_definition_syntax.rst
+++ b/includes_cookbooks/includes_cookbooks_definition_syntax.rst
@@ -13,7 +13,7 @@ The basic syntax of a definition:
 
 .. code-block:: ruby
 
-   define :resource_name, :parameter => :argument, :parameter => :argument
+   define :resource_name, :parameter => :argument, :parameter => :argument do
      params_hash
    end
 


### PR DESCRIPTION
The definition syntax page is missing a do on the first line of the "basic syntax" example.

This request includes a fix.
