### PR TITLE
Fixed names for loop_over_array and loop_over_hash

### DIFF
--- a/steps/step_chef_recipe_loop_over_array_of_package_names.rst
+++ b/steps/step_chef_recipe_loop_over_array_of_package_names.rst
@@ -1,13 +1,18 @@
 .. This is an included how-to. 
 
-A hash is a collection of key-value pairs. Indexing for a hash is done using arbitrary keys of any object (as opposed to the indexing done by an array). The syntax for a hash is: ``key => "value"``.
+A loop statement is used to execute a block of code one (or more) times. A loop statement is created when ``.each`` is added to an expression that defines an array or a hash. An array is an integer-indexed collection of objects. Each element in an array can be associated with and referred to by an index.
 
-To loop over a hash of gem package names:
+To loop over an array of package names by platform:
 
 .. code-block:: ruby
 
-   {"fog" => "0.6.0", "highline" => "1.6.0"}.each do |g,v|
-     gem_package g do
-       version v
-     end
+   ["apache2", "apache2-mpm"].each do |p|
+     package p
    end
+
+
+
+
+
+
+

--- a/steps/step_chef_recipe_loop_over_array_of_package_names.rst
+++ b/steps/step_chef_recipe_loop_over_array_of_package_names.rst
@@ -9,10 +9,3 @@ To loop over an array of package names by platform:
    ["apache2", "apache2-mpm"].each do |p|
      package p
    end
-
-
-
-
-
-
-

--- a/steps/step_chef_recipe_loop_over_hash_of_package_names.rst
+++ b/steps/step_chef_recipe_loop_over_hash_of_package_names.rst
@@ -1,18 +1,13 @@
 .. This is an included how-to. 
 
-A loop statement is used to execute a block of code one (or more) times. A loop statement is created when ``.each`` is added to an expression that defines an array or a hash. An array is an integer-indexed collection of objects. Each element in an array can be associated with and referred to by an index.
+A hash is a collection of key-value pairs. Indexing for a hash is done using arbitrary keys of any object (as opposed to the indexing done by an array). The syntax for a hash is: ``key => "value"``.
 
-To loop over an array of package names by platform:
+To loop over a hash of gem package names:
 
 .. code-block:: ruby
 
-   ["apache2", "apache2-mpm"].each do |p|
-     package p
+   {"fog" => "0.6.0", "highline" => "1.6.0"}.each do |g,v|
+     gem_package g do
+       version v
+     end
    end
-
-
-
-
-
-
-


### PR DESCRIPTION
Names of "Loop over an array of package names" and "Loop over a hash of package names" partials are swapped. You may see it at the bootom of http://docs.opscode.com/essentials_cookbook_recipes_use_ruby.html . Fix attached. Also trailing newlines are dropped (second commit).
