### PR TITLE
Add comment marker to library example

### DIFF
--- a/steps/step_cookbooks_library_create_namespace.rst
+++ b/steps/step_cookbooks_library_create_namespace.rst
@@ -41,7 +41,7 @@ A database can contain a list of virtual hosts that are used by customers. A cus
 
 After the custom namespace is created, it could then be used in a recipe, like this::
 
-   Using ISP.vhosts in a Recipe
+   # Using ISP.vhosts in a Recipe
    ISP.vhosts.each do |vhost|
      directory vhost[:documentroot] do
        owner vhost[:uid]


### PR DESCRIPTION
This code block looked to be Ruby, but the first line was supposed to be a comment.

This makes it a comment so that the whole thing is syntactically valid.
