### PR TITLE
knife.rb reference is missing http_proxy authentication directives

### DIFF
--- a/includes_config/includes_config_rb_knife_settings.rst
+++ b/includes_config/includes_config_rb_knife_settings.rst
@@ -52,6 +52,10 @@ This configuration file has the following settings:
        ::
  
           http_proxy "http://proxy.vmware.com:3128"
+   * - ``http_proxy_user``
+     - |http_proxy_user|
+   * - ``http_proxy_pass``
+     - |http_proxy_pass|
    * - ``node_name``
      - |node_name| This is typically also the same name as the computer from which |knife| is run. For example:
        ::


### PR DESCRIPTION
Missing proxy authentication parameters from knife.rb reference
