### PR TITLE
Added documentation for keep_releases attribute

### DIFF
--- a/includes_resources/includes_resource_deploy_attributes.rst
+++ b/includes_resources/includes_resource_deploy_attributes.rst
@@ -27,6 +27,8 @@ This resource has the following attributes:
      - |environment resource deploy|
    * - ``group``
      - |group resource deploy|
+   * - ``keep_releases``
+     - |keep_releases resource deploy|
    * - ``migrate``
      - |migrate resource deploy|
    * - ``migration_command``

--- a/swaps/swap_desc_k.txt
+++ b/swaps/swap_desc_k.txt
@@ -7,6 +7,7 @@
 .. 
 
 .. |keepalive lwrp application_python_gunicorn| replace:: The amount of time (in seconds) to wait for requests on a |keepalived| connection.
+.. |keep_releases resource deploy| replace:: The number of releases to keep a backup of. Default value: ``5``.
 .. |kerberos-realm| replace:: The administrative domain to which a user belongs.
 .. |kerberos-service| replace:: The service principal used during |kerberos|-based authentication.
 .. |key| replace:: The private key that |knife| will use to sign requests made by the |chef api client| to the |chef server|.


### PR DESCRIPTION
This was missing from the deploy resource pages.
