### PR TITLE
add 'sudo' for chef-server-ctl test on server install docs

### DIFF
--- a/step_install/step_install_server.rst
+++ b/step_install/step_install_server.rst
@@ -22,7 +22,7 @@ To install |chef server 11|, do the following:
 
    .. code-block:: bash
 
-      $ chef-server-ctl test
+      $ sudo chef-server-ctl test
 
    This will run the |chef pedant| test suite against the installed |chef server 11| and will report back that everything is working and installed correctly.
 


### PR DESCRIPTION
Because it fails with:

```
smith@chef:~$ chef-server-ctl test
/opt/chef-server/embedded/service/chef-pedant/lib/pedant/config.rb:34:in `from_argv': Configuration file '/var/opt/chef-server/chef-pedant/etc/pedant_config.rb' not found! (RuntimeError)
        from /opt/chef-server/embedded/service/chef-pedant/lib/pedant.rb:44:in `setup'
        from ./bin/chef-pedant:26:in `<main>'
```

if you don't use sudo.
