### PR TITLE
Added version specifier to environment docs

### DIFF
--- a/includes_environment/includes_environment_format_json.rst
+++ b/includes_environment/includes_environment_format_json.rst
@@ -16,7 +16,7 @@ The |json| format for environments maps directly to the domain-specific |ruby| f
      "json_class": "Chef::Environment",
      "description": "",
       "cookbook_versions": {
-       "couchdb": "11.0.0"
+       "couchdb": "= 11.0.0"
      },
      "chef_type": "environment"
      }

--- a/includes_environment/includes_environment_format_ruby.rst
+++ b/includes_environment/includes_environment_format_ruby.rst
@@ -95,7 +95,7 @@ where both default and override attributes are optional and either a cookbook or
 
    name "dev"
    description "The development environment"
-   cookbook_versions  "couchdb" => "11.0.0"
+   cookbook_versions  "couchdb" => "= 11.0.0"
    default_attributes "apache2" => { "listen_ports" => [ "80", "443" ] }
 
 Or (using the same scenario) to specify a version constraint for only one cookbook:


### PR DESCRIPTION
The version specifier is required in Cher server 11. Updated the environment
docs to reflect this.

I was upgrading my Chef server from 10 to 11 and was having trouble running `knife environment from file environments/myenv.json`. Turns out that this was happening when I had cookbooks in `cookbook_versions` without a version specifier. I just happened to notice that the ruby DSL for environment files had the version specifier included in the docs, but the JSON area did not. This update makes them consistent.
