### PR TITLE
library writing documentation: Update references of @node to node

### DIFF
--- a/steps/step_cookbooks_library_loop_over_records.rst
+++ b/steps/step_cookbooks_library_loop_over_records.rst
@@ -26,7 +26,7 @@ A simple library could be created that extends ``Chef::Recipe::``, like this::
    class Chef
      class Recipe
        def all_customers(&block)
-         @node[:mycompany_customers].each do |name, info|
+         node[:mycompany_customers].each do |name, info|
            block.call(name, info)
          end
        end

--- a/steps/step_cookbooks_library_store_attributes_in_file.rst
+++ b/steps/step_cookbooks_library_store_attributes_in_file.rst
@@ -33,7 +33,7 @@ A simple library could be created that extends ``Chef::Recipe::``, like this::
      class Recipe    
        # A shortcut to a customer
        def customer(name)
-         @node[:mycompany_customers][name]
+         node[:mycompany_customers][name]
        end
      end 
    end


### PR DESCRIPTION
Since @node is deprecated, code samples should be updated to use node instead.
