### PR TITLE
replace some misused "github" references to "git"

### DIFF
--- a/chef_master/source/chef_quick_overview.rst
+++ b/chef_master/source/chef_quick_overview.rst
@@ -26,7 +26,7 @@ Repository
 -----------------------------------------------------
 .. include:: ../../includes_repository/includes_repository.rst
 
-|github| is the most common location to store a |chef| repository that is used with a |chef hosted| account.
+|git| is the most common location to store a |chef| repository that is used with a |chef hosted| account.
 
 The Hosted Chef Server
 =====================================================

--- a/chef_master/source/resource_bash.rst
+++ b/chef_master/source/resource_bash.rst
@@ -34,7 +34,7 @@ Examples
 
 .. include:: ../../step_resource/step_resource_remote_file_install_with_bash.rst
 
-**Install an application from github using bash**
+**Install an application from git using bash**
 
 .. include:: ../../step_resource/step_resource_scm_use_bash_and_ruby_build.rst
 

--- a/chef_master/source/resource_git.rst
+++ b/chef_master/source/resource_git.rst
@@ -36,10 +36,10 @@ Examples
 
 .. include:: ../../step_resource/step_resource_scm_use_different_branches.rst
 
-**Install an application from github using bash**
+**Install an application from git using bash**
 
 .. include:: ../../step_resource/step_resource_scm_use_bash_and_ruby_build.rst
 
-**Upgrade packages from github**
+**Upgrade packages from git**
 
 .. include:: ../../step_resource/step_resource_scm_upgrade_packages.rst

--- a/chef_master/source/resource_scm.rst
+++ b/chef_master/source/resource_scm.rst
@@ -6,7 +6,7 @@ scm
 
 .. include:: ../../includes_resources/includes_resource_scm.rst
 
-This resource is the base resource for two other commonly-used resources: |resource scm_subversion| and |resource scm_git|. While it is possible to use the |resource scm| resource to access content stored in either |github| or |svn|, the recommendation is to use the |resource scm_subversion| resource with |svn| and to use the |resource scm_git| resource with |git|. For more information, see the following topics:
+This resource is the base resource for two other commonly-used resources: |resource scm_subversion| and |resource scm_git|. While it is possible to use the |resource scm| resource to access content stored in either |git| or |svn|, the recommendation is to use the |resource scm_subversion| resource with |svn| and to use the |resource scm_git| resource with |git|. For more information, see the following topics:
 
 * :doc:`git </resource_git>`
 * :doc:`subversion </resource_subversion>`
@@ -45,11 +45,11 @@ Examples
 
 .. include:: ../../step_resource/step_resource_scm_use_different_branches.rst
 
-**Install an application from github using bash**
+**Install an application from git using bash**
 
 .. include:: ../../step_resource/step_resource_scm_use_bash_and_ruby_build.rst
 
-**Upgrade packages from github**
+**Upgrade packages from git**
 
 .. include:: ../../step_resource/step_resource_scm_upgrade_packages.rst
 

--- a/chef_master/source/resource_script.rst
+++ b/chef_master/source/resource_script.rst
@@ -46,7 +46,7 @@ Examples
 
 .. include:: ../../step_resource/step_resource_remote_file_install_with_bash.rst
 
-**Install an application from github using bash**
+**Install an application from git using bash**
 
 .. include:: ../../step_resource/step_resource_scm_use_bash_and_ruby_build.rst
 

--- a/docs_all/source/resources.rst
+++ b/docs_all/source/resources.rst
@@ -341,7 +341,7 @@ Examples
 
 .. include:: ../../step_resource/step_resource_remote_file_install_with_bash.rst
 
-**Install an application from github using bash**
+**Install an application from git using bash**
 
 .. include:: ../../step_resource/step_resource_scm_use_bash_and_ruby_build.rst
 
@@ -1119,11 +1119,11 @@ Examples
 
 .. include:: ../../step_resource/step_resource_scm_use_different_branches.rst
 
-**Install an application from github using bash**
+**Install an application from git using bash**
 
 .. include:: ../../step_resource/step_resource_scm_use_bash_and_ruby_build.rst
 
-**Upgrade packages from github**
+**Upgrade packages from git**
 
 .. include:: ../../step_resource/step_resource_scm_upgrade_packages.rst
 
@@ -2044,7 +2044,7 @@ scm
 
 .. include:: ../../includes_resources/includes_resource_scm.rst
 
-This resource is the base resource for two other commonly-used resources: |resource scm_subversion| and |resource scm_git|. While it is possible to use the |resource scm| resource to access content stored in either |github| or |svn|, the recommendation is to use the |resource scm_subversion| resource with |svn| and to use the |resource scm_git| resource with |git|. For more information, see the following resources:
+This resource is the base resource for two other commonly-used resources: |resource scm_subversion| and |resource scm_git|. While it is possible to use the |resource scm| resource to access content stored in either |git| or |svn|, the recommendation is to use the |resource scm_subversion| resource with |svn| and to use the |resource scm_git| resource with |git|. For more information, see the following resources:
 
 * git
 * subversion
@@ -2083,11 +2083,11 @@ Examples
 
 .. include:: ../../step_resource/step_resource_scm_use_different_branches.rst
 
-**Install an application from github using bash**
+**Install an application from git using bash**
 
 .. include:: ../../step_resource/step_resource_scm_use_bash_and_ruby_build.rst
 
-**Upgrade packages from github**
+**Upgrade packages from git**
 
 .. include:: ../../step_resource/step_resource_scm_upgrade_packages.rst
 
@@ -2129,7 +2129,7 @@ Examples
 
 .. include:: ../../step_resource/step_resource_remote_file_install_with_bash.rst
 
-**Install an application from github using bash**
+**Install an application from git using bash**
 
 .. include:: ../../step_resource/step_resource_scm_use_bash_and_ruby_build.rst
 

--- a/includes_knife/includes_knife_diff.rst
+++ b/includes_knife/includes_knife_diff.rst
@@ -3,5 +3,5 @@
 .. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
 
 
-|knife diff| For example, to compare files on the |chef server| prior to an uploading or downloading files using the ``knife download`` and ``knife upload`` subcommands, or to ensure that certain files in multiple production environments are the same. This subcommand is similar to the ``git diff`` command that can be used to diff what is in the |chef| repository with what is synced to a |github| repository.
+|knife diff| For example, to compare files on the |chef server| prior to an uploading or downloading files using the ``knife download`` and ``knife upload`` subcommands, or to ensure that certain files in multiple production environments are the same. This subcommand is similar to the ``git diff`` command that can be used to diff what is in the |chef| repository with what is synced to a |git| repository.
 

--- a/includes_resources/includes_resource_scm_git.rst
+++ b/includes_resources/includes_resource_scm_git.rst
@@ -1,4 +1,4 @@
 .. The contents of this file are included in multiple topics.
 .. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
 
-|resource desc scm_git| |github| version 1.6.5 (or higher) is required to use all of the functionality in the |resource scm_git| resource.
+|resource desc scm_git| |git| version 1.6.5 (or higher) is required to use all of the functionality in the |resource scm_git| resource.

--- a/pdf_reference_resources/source/resources.rst
+++ b/pdf_reference_resources/source/resources.rst
@@ -1435,7 +1435,7 @@ Examples
 
 .. include:: ../../step_resource/step_resource_remote_file_install_with_bash.rst
 
-**Install an application from github using bash**
+**Install an application from git using bash**
 
 .. include:: ../../step_resource/step_resource_scm_use_bash_and_ruby_build.rst
 

--- a/swaps/swap_desc_l.txt
+++ b/swaps/swap_desc_l.txt
@@ -188,10 +188,10 @@
 .. |lwrp action stop supervisor_fcgi| replace:: Use to stop a |fcgi| process.
 .. |lwrp action stop supervisor_group| replace:: Use to stop a group.
 .. |lwrp action stop supervisor_service| replace:: Use to stop a service.
-.. |lwrp action tap homebrew| replace:: Use to enable a formula repository located on |github|.
+.. |lwrp action tap homebrew| replace:: Use to enable a formula repository located on |git|.
 .. |lwrp action term daemontools_service| replace:: Use to send the ``TERM`` signal. The following command is used: ``svc -t``.
 .. |lwrp action upgrade homebrew| replace:: This action is inherited from the |resource package| resource resource. For |homebrew|, there isn't an upgrade, rather |homebrew| performs the ``:install`` action every time, effectively upgrading a package when it is newer than the one installed previously.
-.. |lwrp action untap homebrew| replace:: Use to disable a formula repository located on |github|.
+.. |lwrp action untap homebrew| replace:: Use to disable a formula repository located on |git|.
 .. |lwrp action unzip windows_zipfile| replace:: Use to unzip a compressed file.
 .. |lwrp action up daemontools_service| replace:: Use to start a service. If the service stops, restart it. The following command is used: ``svc -u``.
 .. |lwrp action update aws_resource_tag| replace:: Use to modify a tag already assigned to a resource.

--- a/swaps/swap_desc_n.txt
+++ b/swaps/swap_desc_n.txt
@@ -15,7 +15,7 @@
 .. |name lwrp firewall| replace:: An arbitrary name that is used to uniquely identify the resource.
 .. |name lwrp firewall_rule| replace:: A unique name for a firewall rule.
 .. |name lwrp freebsd| replace:: The name of the port for which a port options file will be modified.
-.. |name lwrp homebrew| replace:: The name of a formula repository located on |github|.
+.. |name lwrp homebrew| replace:: The name of a formula repository located on |git|.
 .. |name lwrp windows_autorun| replace:: The name of a value to be stored in the |windows| registry.
 .. |name lwrp windows_shortcut| replace:: The name of the shortcut.
 .. |name only| replace:: Indicates that only the names of modified files will be shown.

--- a/swaps/swap_desc_r.txt
+++ b/swaps/swap_desc_r.txt
@@ -167,7 +167,7 @@
 .. |resource desc route| replace:: The |resource route| resource is used to manage the system routing table in a |linux| environment.
 .. |resource desc ruby_block| replace:: The |resource ruby_block| resource is used to execute |ruby| code during a |chef| run. |ruby| code in the ``ruby_block`` resource is evaluated with other resources during convergence, whereas |ruby| code outside of a ``ruby_block`` resource is evaluated before other resources, as the recipe is compiled.
 .. |resource desc scm| replace:: The |resource scm| resource is used to manage source control resources that exist in a |git| repository or a |svn| repository.
-.. |resource desc scm_git| replace:: The |resource scm_git| resource is used to manage source control resources that exist in a |github| repository.
+.. |resource desc scm_git| replace:: The |resource scm_git| resource is used to manage source control resources that exist in a |git| repository.
 .. |resource desc scm_svn| replace:: The |resource scm_subversion| resource is used to manage source control resources that exist in a |svn| repository.
 .. |resource desc script| replace:: The |resource script| resource is used to execute scripts using the specified interpreter (|bash|, |csh|, |perl|, |python|, or |ruby|) and includes all of the actions and attributes that are available to the |resource execute| resource.
 .. |resource desc script_bash| replace:: The |resource script_bash| resource is used to execute scripts using the |bash| interpreter and includes all of the actions and attributes that are available to the |resource execute| resource.


### PR DESCRIPTION
It seems that in some places it is using the word "github", when it's actually talking about "git".
