### PR TITLE
Fix incorrect command to enable ntpd on RHEL6/CentOS6 systems.

### DIFF
--- a/includes_private_chef_1x/includes_private_chef_1x_install_prerequisites_os_ntp.rst
+++ b/includes_private_chef_1x/includes_private_chef_1x_install_prerequisites_os_ntp.rst
@@ -6,7 +6,7 @@
 .. code-block:: bash
 
    $ yum install ntp
-   $ chkconfig --add ntp
+   $ chkconfig ntpd on
    $ service ntpd start
 
 For |ubuntu|:


### PR DESCRIPTION
The service is 'ntpd' and doesn't need to be "--add"ed, just enabled.
