### PR TITLE
Fix for a typo in essentials_cookbook_recipes_tags and related pot files.

### DIFF
--- a/chef_master/translate/dsl_recipe_method_tag.pot
+++ b/chef_master/translate/dsl_recipe_method_tag.pot
@@ -28,7 +28,7 @@ msgstr ""
 
 #: ../../includes_cookbooks/includes_cookbooks_recipe_tags.rst:4
 # 07664eab585246da80ada0ab58188f53
-msgid "Tags can be added and remove. Machines can be checked to see if they already have a specific tag. To use tags in your recipe simply add the following:"
+msgid "Tags can be added and removed. Machines can be checked to see if they already have a specific tag. To use tags in your recipe simply add the following:"
 msgstr ""
 
 #: ../../includes_cookbooks/includes_cookbooks_recipe_tags.rst:10

--- a/chef_master/translate/essentials_cookbook_recipes.pot
+++ b/chef_master/translate/essentials_cookbook_recipes.pot
@@ -711,7 +711,7 @@ msgstr ""
 
 #: ../../includes_cookbooks/includes_cookbooks_recipe_tags.rst:4
 # 2771a3011f7a42898479d7e513138b25
-msgid "Tags can be added and remove. Machines can be checked to see if they already have a specific tag. To use tags in your recipe simply add the following:"
+msgid "Tags can be added and removed. Machines can be checked to see if they already have a specific tag. To use tags in your recipe simply add the following:"
 msgstr ""
 
 #: ../../includes_cookbooks/includes_cookbooks_recipe_tags.rst:10

--- a/includes_cookbooks/includes_cookbooks_recipe_tags.rst
+++ b/includes_cookbooks/includes_cookbooks_recipe_tags.rst
@@ -1,7 +1,7 @@
 .. The contents of this file are included in multiple topics.
 .. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
 
-Tags can be added and remove. Machines can be checked to see if they already have a specific tag. To use tags in your recipe simply add the following:
+Tags can be added and removed. Machines can be checked to see if they already have a specific tag. To use tags in your recipe simply add the following:
 
 .. code-block:: ruby
 


### PR DESCRIPTION
Simply typo in one of the lines in the tag documentation.
