### PR TITLE
Add more services to OPC firewall list

### DIFF
--- a/includes_private_chef_1x/includes_private_chef_1x_install_tiered_network_firewalls.rst
+++ b/includes_private_chef_1x/includes_private_chef_1x_install_tiered_network_firewalls.rst
@@ -28,26 +28,51 @@ On the back-end servers:
      - nginx
    * - 443
      - nginx
-   * - 9671
-     - nginx
-   * - 9680
-     - nginx
-   * - 9685
-     - nginx
-   * - 9683
-     - nginx
-   * - 9672
-     - nrpe
-   * - 5984
-     - couchdb
-   * - 8983
-     - opscode-solr
+   * - 4321
+     - bookshelf
+   * - 4369
+     - opscode-org-creator
+   * - 5140
+     - opscode-certificate
    * - 5432
      - postgresql
    * - 5672
      - rabbitmq
+   * - 5984
+     - couchdb
    * - 6379
      - redis
-
+   * - 7788
+     - drbd
+   * - 8000
+     - opscode-erchef
+   * - 8983
+     - opscode-solr
+   * - 9000
+     - nagios
+   * - 9460
+     - opscode-chef
+   * - 9462
+     - opscode-webui
+   * - 9463
+     - opscode-authz
+   * - 9465
+     - opscode-account
+   * - 9466
+     - estatsd
+   * - 9670
+     - nagios
+   * - 9671
+     - nagios
+   * - 9672
+     - nrpe
+   * - 9671
+     - nginx
+   * - 9680
+     - nginx
+   * - 9683
+     - nginx
+   * - 9685
+     - nginx
 
 Refer to the operating systems manual or a site systems administrators for instructions on how to enable this change.


### PR DESCRIPTION
This is based on review of the attributes in the opscode-omnibus and the Omnibus Private Chef Assigned Numbers Authority page on the Opscode corporate wiki.

It also arranges the list by port number.
