### PR TITLE
Remove env_run_lists from environment attributes

### DIFF
--- a/includes_environment/includes_environment_format_ruby.rst
+++ b/includes_environment/includes_environment_format_ruby.rst
@@ -42,13 +42,6 @@ Domain-specific |ruby| attributes for environments include the following:
        ::
 
           description 'The development environment'
-   * - ``env_run_lists``
-     - |ruby dsl environment run list| For example:
-       ::
-
-          env_run_lists "prod" => ["recipe[apache2]"], 
-                                   "staging" => ["recipe[apache2::staging]"], 
-                                   "_default" => []
    * - ``name``
      - |ruby dsl name| For example:
        ::


### PR DESCRIPTION
The `env_run_lists` cannot be used inside environments. This attribute is only for roles.

Related thread in the mailing list: http://lists.opscode.com/sympa/arc/chef/2013-06/msg00429.html
