### PR TITLE
Fixed an incorrect header in the Chef Server API docs on authentication

### DIFF
--- a/includes_api_chef_server/includes_api_chef_server_headers_format.rst
+++ b/includes_api_chef_server/includes_api_chef_server_headers_format.rst
@@ -7,7 +7,7 @@ All hashing is done using |sha1| and encoded in |base64|. |base64| encoding shou
 .. code-block:: bash
 
    Method:HTTP_METHOD
-   HashedPath:HASHED_PATH
+   Hashed Path:HASHED_PATH
    X-Ops-Content-Hash:HASHED_BODY
    X-Ops-Timestamp:TIME
    X-Ops-UserId:USERID


### PR DESCRIPTION
The authentication section on the Chef Server API documentation referred to the encrypted signature block containing a `HashedPath` line, however the header should actually be `Hashed Path` (with a space).  Minor, but threw me a curveball until I looked at the mixlib source. :smile: 
