### PR TITLE
Correct orgmapper directions for adding a user to a group.

### DIFF
--- a/step_orgmapper/step_orgmapper_add_user_to_admin_group.rst
+++ b/step_orgmapper/step_orgmapper_add_user_to_admin_group.rst
@@ -1,9 +1,11 @@
-.. This is an included how-to. 
+.. This is an included how-to.
 
 .. To add a user to an organization's admin group:
 
 .. code-block:: ruby
 
-   orgmapper:0> ORGS['ORGNAME'].add_user_to_group('USERNAME', 'admins')
+   orgmapper:0> g = ORGS['ORGNAME'].groups['admins']
+   orgmapper:0> g.add_actor(USERS['USERNAME'])
+   orgmapper:0> g.save
 
 where ``ORGNAME`` is the name of the organization and ``USERNAME`` is the name of the user.


### PR DESCRIPTION
The #add_user_to_group method does not work in many versions of
orgmapper.  This alternate procedure does work.
