### PR TITLE
Fix OPC log_rotation default value and example

### DIFF
--- a/includes_private_chef_1x/includes_private_chef_1x_admin_configure_general_log_rotation.rst
+++ b/includes_private_chef_1x/includes_private_chef_1x_admin_configure_general_log_rotation.rst
@@ -11,40 +11,22 @@ This configuration file has the following settings for log rotation:
    * - Setting
      - Description
    * - ``log_rotation``
-     - For configuring log rotation on files that are not managed by svlogd or rotated by the application itself. Default value:
+     - For configuring log rotation on files that are not managed by svlogd or rotated by the application itself.
+
+       Default value:
        ::
 
-          {
-            "/var/log/opscode/nginx/*.log" => {
-              "rotate" => 14
-            },
-            "/var/log/opscode/php-fpm/php-fpm.log" => {
-              "rotate" => 14
-            },
-            "/var/log/opscode/couchdb/couchdb.log" => {
-              "rotate" => 14
-            },
-            "/var/log/opscode/nagios/nagios.log" => {
-              "rotate" => 14
-            },
-          }
+          log_rotation["/var/log/opscode/nginx/*.log"] = { "rotate" => 14 }
+          log_rotation["/var/log/opscode/php-fpm/php-fpm.log"] = { "rotate" => 14 }
+          log_rotation["/var/log/opscode/couchdb/couchdb.log"] = { "rotate" => 14, "owner"=>"opscode", "group"=>"opscode" }
+          log_rotation["/var/log/opscode/nagios/nagios.log"] = { "rotate" => 14 }
 
        For example:
        ::
 
-          log_rotation = {
-            "/var/log/opscode/nginx/*.log" => {
-              "rotate" => 14
-            },
-            "/var/log/opscode/php-fpm/php-fpm.log" => {
-              "rotate" => 14
-            },
-            "/var/log/opscode/couchdb/couchdb.log" => {
-              "rotate" => 14
-            },
-            "/var/log/opscode/nagios/nagios.log" => {
-             "rotate" => 14
-            },
-          }
+          log_rotation["/var/log/opscode/nginx/*.log"] = { "rotate" => 7 }
+          log_rotation["/var/log/opscode/php-fpm/php-fpm.log"] = { "rotate" => 7 }
+          log_rotation["/var/log/opscode/couchdb/couchdb.log"] = { "rotate" => 7, "owner"=>"opscode", "group"=>"opscode" }
+          log_rotation["/var/log/opscode/nagios/nagios.log"] = { "rotate" => 7 }
 
 


### PR DESCRIPTION
Setting log_rotation to a complete nested hash will not work.
The log_rotation values must be specified one key at a time.
