### PR TITLE
chef_master/source/resource_log.rst includes wrong step_resource

### DIFF
--- a/chef_master/source/resource_log.rst
+++ b/chef_master/source/resource_log.rst
@@ -36,7 +36,7 @@ Examples
 
 **Create log entry when the contents of a data bag are used**
 
-.. include:: ../../step_resource/step_resource_log_set_debug.rst
+.. include:: ../../step_resource/step_resource_log_create_log_entry_for_data_bag.rst
 
 **Add a message to a log file**
 


### PR DESCRIPTION
in examples at http://docs.opscode.com/resource_log.html ,
both "Set debug logging level" and "Create log entry when the contents of a data bag are used" show same example.
