### PR TITLE
Fix Sphinx warnings found when building.

### DIFF
--- a/includes_config/includes_config_rb_11-4_client_settings.rst
+++ b/includes_config/includes_config_rb_11-4_client_settings.rst
@@ -98,7 +98,7 @@ This configuration file has the following settings:
  
           interval 1800
    * - ``json_attribs``
-     - |json attributes | For example:
+     - |json attributes| For example:
        ::
  
           json_attribs nil

--- a/includes_environment_variables/includes_environment_variables_child_processes.rst
+++ b/includes_environment_variables/includes_environment_variables_child_processes.rst
@@ -49,7 +49,7 @@ In |ruby|, the current environment can be altered via the ``ENV`` variable. Any 
    EOF
    end
 
-When run, the |resource bash| resource will correctly ``echo "bar"`` to its standard output.
+When run, the |resource script_bash| resource will correctly ``echo "bar"`` to its standard output.
 
 However, just as in |bash|, changes made in child processes have no affect on the parent, and thus no affect on subsequent child processes:
 
@@ -67,4 +67,4 @@ However, just as in |bash|, changes made in child processes have no affect on th
    EOF
    end
 
-When run, the second |resource bash| resource will not cause anything to be echoed to standard out as ``BAZ`` is not part of its environment.
+When run, the second |resource script_bash| resource will not cause anything to be echoed to standard out as ``BAZ`` is not part of its environment.


### PR DESCRIPTION
``` shell
includes_config/includes_config_rb_11-4_client_settings.rst:101: WARNING: Inline substitution_reference start-string without end-string.
includes_environment_variables/includes_environment_variables_child_processes.rst:52: ERROR: Undefined substitution referenced: "resource bash".
includes_environment_variables/includes_environment_variables_child_processes.rst:70: ERROR: Undefined substitution referenced: "resource bash".
```
