### PR TITLE
In Chef >= 11, you must specify a precedence of attributes when setting them in recipes.

### DIFF
--- a/includes_resources/includes_resource_directory_syntax.rst
+++ b/includes_resources/includes_resource_directory_syntax.rst
@@ -33,7 +33,7 @@ Also, a variable can be used to define the directory, and then that variable can
 
 .. code-block:: ruby
 
-   node['apache']['dir'] = '/etc/apache2'
+   node.default['apache']['dir'] = '/etc/apache2'
    
    directory node['apache']['dir'] do
      owner 'apache'


### PR DESCRIPTION
The old bare syntax of node['something'] in recipe context is no longer supported.
