### PR TITLE
fix resource group "name" description

### DIFF
--- a/chef_master/translate/resource_group.pot
+++ b/chef_master/translate/resource_group.pot
@@ -73,7 +73,7 @@ msgstr ""
 
 #: ../../includes_resources/includes_resource_group_syntax.rst:17
 # 8e2d3a6ccb3642969b24a30e30269fce
-msgid "``\"name\"`` is the security group"
+msgid "``\"name\"`` is the name of the group"
 msgstr ""
 
 #: ../../includes_resources/includes_resource_group_syntax.rst:18

--- a/includes_resources/includes_resource_group_syntax.rst
+++ b/includes_resources/includes_resource_group_syntax.rst
@@ -14,6 +14,6 @@ The syntax for using the |resource group| resource in a recipe is as follows:
 where 
 
 * ``group`` tells the |chef client| to use one of the following providers during the |chef client| run: ``Chef::Provider::Group``, ``Chef::Provider::Group::Aix``, ``Chef::Provider::Group::Dscl``, ``Chef::Provider::Group::Gpasswd``, ``Chef::Provider::Group::Groupadd``, ``Chef::Provider::Group::Groupmod``, ``Chef::Provider::Group::Pw``, ``Chef::Provider::Group::Suse``, ``Chef::Provider::Group::Usermod``, or ``Chef::Provider::Group::Windows``. The provider that is used by the |chef client| depends on the platform of the machine on which the |chef client| run is taking place
-* ``"name"`` is the security group
+* ``"name"`` is the name of the group
 * ``attribute`` is zero (or more) of the attributes that are available for this resource
 * ``:action`` is the step that the resource will ask the provider to take during the |chef client| run


### PR DESCRIPTION
i think "name" attribute of resource "group" is "the name of the group", not "the security group".
