### PR TITLE
Fix ambiguous usage of comma-separated run list items in run_list add.

### DIFF
--- a/step_knife/step_knife_node_run_list_add_roles_and_recipes.rst
+++ b/step_knife/step_knife_node_run_list_add_roles_and_recipes.rst
@@ -5,4 +5,4 @@ To add roles and recipes to a run list, enter:
 
 .. code-block:: bash
 
-   $ knife node run_list add node 'recipe[COOKBOOK::RECIPE_NAME],COOKBOOK::RECIPE_NAME,role[ROLE_NAME]'
+   $ knife node run_list add node 'recipe[COOKBOOK::RECIPE_NAME],recipe[COOKBOOK::RECIPE_NAME],role[ROLE_NAME]'


### PR DESCRIPTION
I'm not sure if the bare "COOKBOOK::RECIPE_NAME" works, but it's ambiguous so I'd argue it's discouraged.
