### PR TITLE
knife.rb config cleanups

### DIFF
--- a/includes_repository/includes_repository_many_users_same_repo.rst
+++ b/includes_repository/includes_repository_many_users_same_repo.rst
@@ -13,28 +13,19 @@ It is possible for multiple users to access the |chef server| using the same |kn
      validation_client_name   "#{ENV['ORGNAME']}-validator"
      validation_key           "#{ENV['HOME']}/.chef/#{ENV['ORGNAME']}-validator.pem"
      chef_server_url          "https://api.opscode.com/organizations/#{ENV['ORGNAME']}"
-     cache_type               'BasicFile'
-     cache_options( :path => "#{ENV['HOME']}/.chef/checksums" )
+     syntax_check_cache_path  "#{ENV['HOME']}/.chef/syntax_check_cache"
      cookbook_path            ["#{current_dir}/../cookbooks"]
      cookbook_copyright "Your Company, Inc."
      cookbook_license "apachev2"
      cookbook_email "cookbooks@yourcompany.com"
    
-     # all your credentials are belong to us
-   
      # Amazon AWS
-     knife[:aws_access_key_id] = "#{ENV['AWS_ACCESS_KEY_ID']}"
-     knife[:aws_secret_access_key] = "#{ENV['AWS_SECRET_ACCESS_KEY']}"
+     knife[:aws_access_key_id] = ENV['AWS_ACCESS_KEY_ID']
+     knife[:aws_secret_access_key] = ENV['AWS_SECRET_ACCESS_KEY']
    
      # Rackspace Cloud
-     knife[:rackspace_api_username] = "#{ENV['RACKSPACE_USERNAME']}"
-     knife[:rackspace_api_key] = "#{ENV['RACKSPACE_API_KEY']}"   
-
-
-
-
-
-
+     knife[:rackspace_api_username] = ENV['RACKSPACE_USERNAME']
+     knife[:rackspace_api_key] = ENV['RACKSPACE_API_KEY']
 
 
 


### PR DESCRIPTION
cache_\* is deprecated, so encourage people to use the correct syntax for the syntax_check_cache path.

Don't do unnecessary Ruby string interpolation for the AWS and Rackspace keys.

Remove silly comment in config file that might distract people (sorry, @jamescott)
