### PR TITLE
Fix various issues with the Private Chef installation guide

### DIFF
--- a/docs_oec/source/install_server_febe.rst
+++ b/docs_oec/source/install_server_febe.rst
@@ -113,7 +113,7 @@ Refer to the operating systems manual or a site systems administrators for instr
 
 private-chef.rb
 -----------------------------------------------------
-Each |chef server oec| cluster has a single configuration file called |private chef rb|. This file descrsibes the topology of the entire cluster. This file lives in ``/etc/opscode/private-chef.rb`` on each server. Using the text editor of your choice, create a file called |private chef rb|.
+Each |chef server oec| cluster has a single configuration file called |private chef rb|. This file describes the topology of the entire cluster. This file lives in ``/etc/opscode/private-chef.rb`` on each server. Using the text editor of your choice, create a file called |private chef rb|.
 
 Configure topology
 -----------------------------------------------------

--- a/includes_private_chef_1x/includes_private_chef_1x_install_tiered_config_front_end.rst
+++ b/includes_private_chef_1x/includes_private_chef_1x_install_tiered_config_front_end.rst
@@ -1,10 +1,16 @@
 .. The contents of this file may be included in multiple topics.
 .. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
 
-With the bootstrap complete, you can now populate ``/etc/opscode`` on the front-end servers with the files generated during the bootstrap process. Assuming you are logged in as root on your bootstrap server, something like:
+To set up |chef private| on your front-end servers, run:
 
 .. code-block:: bash
 
-   $ scp -r /etc/opscode FQDN:/etc
+   $ private-chef-ctl reconfigure
 
-This command will copy all the files from the bootstrap server to another system. Replace ``FQDN`` with the |fqdn| of the system you want to install.
+This command may take several minutes to run, during which you will see the output of the |chef| run that is configuring your new |chef private| installation. When it is complete, the following message is shown:
+
+.. code-block:: bash
+
+   Chef Server Reconfigured!
+
+.. note:: |chef private| is composed of many different services, which work together to create a functioning system. One impact of this is that it can take a few minutes for the system to finish starting up. One way to tell that the system is fully ready is to use the top command. You will notice high CPU utilization for several |ruby| processes while the system is starting up. When that utilization drops off, the system is ready.

--- a/includes_private_chef_1x/includes_private_chef_1x_install_tiered_network_firewalls.rst
+++ b/includes_private_chef_1x/includes_private_chef_1x_install_tiered_network_firewalls.rst
@@ -16,7 +16,7 @@ If host-based firewalls (iptables, ufw, etc.) are being used, ensure that the fo
    * - 9672
      - nrpe
 
-On the back-end servers:
+On the back-end server:
 
 .. list-table::
    :widths: 60 420

--- a/includes_private_chef_1x/includes_private_chef_1x_install_tiered_private_chef_rb.rst
+++ b/includes_private_chef_1x/includes_private_chef_1x_install_tiered_private_chef_rb.rst
@@ -1,4 +1,4 @@
 .. The contents of this file may be included in multiple topics.
 .. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
 
-Each |chef private| cluster has a single configuration file called |private chef rb|. This file descrsibes the topology of the entire cluster. This file lives in ``/etc/opscode/private-chef.rb`` on each server. Using the text editor of your choice, create a file called |private chef rb|.
+Each |chef private| cluster has a single configuration file called |private chef rb|. This file describes the topology of the entire cluster. This file lives in ``/etc/opscode/private-chef.rb`` on each server. Using the text editor of your choice, create a file called |private chef rb|.

--- a/includes_private_chef_1x/includes_private_chef_1x_install_tiered_private_chef_rb_example.rst
+++ b/includes_private_chef_1x/includes_private_chef_1x_install_tiered_private_chef_rb_example.rst
@@ -23,8 +23,8 @@ A completed |private chef rb| configuration file for a four server tiered |chef 
      - 192.168.4.4
      - frontend
    * - chef.example.com
-     - 192.168.4.5
-     - backend VIP
+     - 
+     - load balanced frontend VIP
 
 Looks like this:
 


### PR DESCRIPTION
- Typos 
- Incorrect labeling in the tiered example
- Incorrect content for the "Configure" subsection of the "Configure Front-end" section of the docs -- see http://docs.opscode.com/server/private_chef_1x_install.html#configure-front-end and notice how it instructs you to scp /etc/opscode twice
