### PR TITLE
Remove extra ruby term preceeding example

### DIFF
--- a/step_lwrp/step_lwrp_supervisor_service_enable.rst
+++ b/step_lwrp/step_lwrp_supervisor_service_enable.rst
@@ -1,14 +1,12 @@
-.. This is an included how-to. 
+.. This is an included how-to.
 
 To enable the |celery| service:
 
 .. code-block:: ruby
 
-   ruby supervisor_service "celery" do 
-     action :enable 
-     autostart false 
-     user "nobody" 
+   supervisor_service "celery" do
+     action :enable
+     autostart false
+     user "nobody"
    end
-
-
 


### PR DESCRIPTION
The example contains a leading 'ruby' statement, probably left over
from a copy/paste of an example in Markdown syntax.

This also removes any trailing whitespace from each line.
