### PR TITLE
[CHEF-4604] remove confusing reference to top level json files

### DIFF
--- a/includes_data_bag/includes_data_bag_directory_structure.rst
+++ b/includes_data_bag/includes_data_bag_directory_structure.rst
@@ -16,7 +16,6 @@ All data bags are stored in the ``data_bags`` directory of the |chef repo|. This
                        |_small.json
                        |_medium.json
                        |_large.json
-            |_standard_packages.json
-            |_global_shell_settings.json
 
-where ``admins``, ``db_users``, ``db_config``, ``standard_packages``, and ``global_shell_settings`` are the names of individual data bags and all of the files that end with ``.json`` are the individual data bag items. 
+
+where ``admins``, ``db_users``, and ``db_config`` are the names of individual data bags and all of the files that end with ``.json`` are the individual data bag items. 


### PR DESCRIPTION
See CHEF-4604 the .json files in the top level of the data_bags folder in the example were very confusing and possibly incorrect so i've removed them for clarity.
