### PR TITLE
Replace Integer with Fixnum.

### DIFF
--- a/includes_dsl_resource/includes_dsl_resource_method_attribute_validation_parameter.rst
+++ b/includes_dsl_resource/includes_dsl_resource_method_attribute_validation_parameter.rst
@@ -53,7 +53,7 @@ A validation parameter is used to add zero (or more) validation parameters to an
        
        .. code-block:: ruby
        
-          :kind_of => Integer
+          :kind_of => Fixnum
        
        .. code-block:: ruby
        


### PR DESCRIPTION
Although Integer does exist in Ruby, it is the abstract superclass to Fixnum and Bignum. Most people will not ever see Integer, so I suggest we use Fixnum here.
