### PR TITLE
OpenStack Architecture revamp and Vagrant documentation

### DIFF
--- a/chef_master/source/openstack_architecture_1+n.rst
+++ b/chef_master/source/openstack_architecture_1+n.rst
@@ -1,0 +1,5 @@
+=====================================================
+|chef openstack|: Architecture: Single Controller + N Compute
+=====================================================
+.. include:: ../../includes_openstack/includes_openstack_architecture_1+n.rst
+

--- a/chef_master/source/openstack_architecture_allinone.rst
+++ b/chef_master/source/openstack_architecture_allinone.rst
@@ -1,0 +1,4 @@
+=====================================================
+|chef openstack|: Architecture: All-in-One Compute
+=====================================================
+.. include:: ../../includes_openstack/includes_openstack_architecture_allinone.rst

--- a/chef_master/source/openstack_vagrant.rst
+++ b/chef_master/source/openstack_vagrant.rst
@@ -1,5 +1,5 @@
 =====================================================
-|chef openstack|: Architecture
+|chef openstack|: Vagrant
 =====================================================
 
-.. include:: ../../includes_openstack/includes_openstack_architecture.rst
+.. include:: ../../includes_openstack/includes_openstack_repo_vagrant.rst

--- a/includes_openstack/includes_openstack_architecture.rst
+++ b/includes_openstack/includes_openstack_architecture.rst
@@ -1,7 +1,7 @@
 .. The contents of this file are included in multiple topics.
 .. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
 
-This section describes the supported deployment scenarios for |chef openstack| and is based on the `OpenStack Grizzly <http://www.solinea.com/2013/06/15/openstack-grizzly-architecture-revisited/>`_ release. 
+This section describes the supported deployment scenarios for |chef openstack| and is based on the `OpenStack Grizzly <http://www.solinea.com/2013/06/15/openstack-grizzly-architecture-revisited/>`_ release.
 
 .. image:: ../../images/openstack-arch-grizzly-conceptual-v2.jpg
 
@@ -13,13 +13,9 @@ There are a number of configuration options available, including block storage, 
 
    * - Scenario
      - Description
-   * - All-in-One Compute
-     - A full |openstack compute| deployment on a single host. No object storage.
-   * - Single Controller + N Compute
+   * - :doc:`All-in-One Compute </openstack_architecture_allinone>`
+     - A full |openstack compute| deployment on a single host or with :doc:`Vagrant </openstack_vagrant>`. No object storage.
+   * - :doc:`Single Controller + N Compute </openstack_architecture_1+n>`
      - A single controller with 1 or more |openstack compute| nodes. No object storage.
 
 .. note:: |chef openstack| is under very active development for the |openstack grizzly| release. |openstack| is flexible and additional configurations will be supported in the future.
-
-
-
-

--- a/includes_openstack/includes_openstack_architecture_1+n.rst
+++ b/includes_openstack/includes_openstack_architecture_1+n.rst
@@ -1,8 +1,8 @@
 .. The contents of this file are included in multiple topics.
 .. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
 
-The **1+N** configuration refers to a single controller and variable number of nodes. This is suitable for relatively small deployments, such as those with fewer than twenty nodes. The size of the deployment depends on the nature of the workload. Compute nodes should typically be given more substantial hardware than the controller node.
+The **Single Controller + N Compute** (aka **1+N**) configuration refers to a single controller and variable number of nodes. This is suitable for relatively small deployments, such as those with fewer than twenty nodes. The size of the deployment depends on the nature of the workload. Compute nodes should typically be given more substantial hardware than the controller node.
 
 * **On the Controller** Compute (services, not the hypervisor), Dashboard, Identity, Image, and Network. The database and messaging services also run on the Controller.
 * **On the Compute Nodes** Compute (hypervisor, not the services)
-* **Excluded** Block Storage, Object Storage, Metering, and Orchestration
+* **Excluded** Object Storage, Metering, and Orchestration

--- a/includes_openstack/includes_openstack_architecture_allinone.rst
+++ b/includes_openstack/includes_openstack_architecture_allinone.rst
@@ -1,7 +1,21 @@
 .. The contents of this file are included in multiple topics.
 .. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
 
-**All-in-One** configurations are appropriate for small scale environments like proof of concept projects, dedicated fenced development environments, or when the host will be a virtual machine. This machine need not be large, but it must be sufficient to launch a few virtual instances, assuming those instances are only used for testing purposes. This configuration is a good way to familiarize yourself with the basics of |chef openstack|.
+**All-in-One Compute** configurations are appropriate for small scale deployments like proof of concept projects, dedicated fenced development environments, or when the host will be a virtual machine. This machine need not be large, but it must be sufficient to launch a few virtual instances, assuming those instances are only used for testing purposes. This configuration is a good way to familiarize yourself with the basics of |chef openstack|.
+
+The All-in-One Compute configuration may be used for testing with :doc:`Vagrant </openstack_vagrant>`
 
 * **On the Controller** Compute, Dashboard, Identity, Image, and Network. The database and messaging services also run on the node.
 * **Excluded** Block Storage, Object Storage, Metering, and Orchestration
+
+Environments
+------------
+
+The :doc:`Vagrant </openstack_vagrant>` configuration uses its own ``vagrant`` environment.
+
+There is an ``allinone`` example Environment that is currently under development and will be documented here soon.
+
+Roles
+-----
+
+There is an ``allinone-compute`` role in the :doc:`OpenStack Chef Repository </openstack_repository>`. This will deploy all of the services for Openstack Compute to function on a single box. The run list is the ``os-compute-single-controller`` and ``os-compute-worker`` roles.

--- a/includes_openstack/includes_openstack_repo_vagrant.rst
+++ b/includes_openstack/includes_openstack_repo_vagrant.rst
@@ -1,5 +1,261 @@
 .. The contents of this file are included in multiple topics.
 .. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
 
+[Vagrant](http://vagrantup.com) is a virtualization framework for managing development environments, it may be used for testing the :doc:`All-in-One </openstack_architecture_allinone>` configuration in the |chef repo openstack|. Vagrant is a third-party tool that may be used with |chef|, but is not required for using the |chef repo openstack|.
 
-placeholder_for_vagrant
+Installation
+------------
+
+Vagrant supports a number of virtualization and cloud back-ends. For our purposes we are using Virtualbox (currently 4.2.18). You may download it from Virtualbox.com.
+
+Install Vagrant 1.2.1 or later from packages. You may download it from https://downloads.vagrantup.com.
+
+Our test configuration requires a number of Vagrant plugins, install the following plugins in exactly this order:
+
+.. code-block:: bash
+
+   $ vagrant plugin install vagrant-omnibus
+   $ vagrant plugin install vagrant-chef-zero
+   $ vagrant plugin install vagrant-berkshelf
+
+Vagrantfile
+-----------
+
+Vagrant uses a **Vagrantfile** for managing its configuration. Within the |chef repo openstack| there is a Vagrantfile that configures the Virtualbox VM for our purposes.
+
+.. code-block:: ruby
+
+   Vagrant.require_plugin "vagrant-berkshelf"
+   Vagrant.require_plugin "vagrant-chef-zero"
+   Vagrant.require_plugin "vagrant-omnibus"
+
+   Vagrant.configure("2") do |config|
+     # Berkshelf plugin configuration
+     config.berkshelf.enabled = true
+
+     # Chef-Zero plugin configuration
+     config.chef_zero.enabled = true
+     config.chef_zero.chef_repo_path = "."
+
+     # Omnibus plugin configuration
+     config.omnibus.chef_version = :latest
+
+     # Port forwarding rules, for access to openstack services
+     config.vm.network "forwarded_port", guest: 443, host: 8443     # dashboard-ssl
+     config.vm.network "forwarded_port", guest: 4000, host: 4000    # chef-zero
+     config.vm.network "forwarded_port", guest: 8773, host: 8773    # compute-ec2-api
+     config.vm.network "forwarded_port", guest: 8774, host: 8774    # compute-api
+
+     # OpenStack-related settings
+     config.vm.network "private_network", ip: "33.33.33.60"
+     config.vm.network "private_network", ip: "192.168.100.60"
+     config.vm.provider "virtualbox" do |vb|
+       vb.customize ["modifyvm", :id, "--cpus", 2]
+       vb.customize ["modifyvm", :id, "--memory", 2048]
+       vb.customize ["modifyvm", :id, "--nicpromisc2", "allow-all"]
+       vb.customize ["modifyvm", :id, "--nicpromisc3", "allow-all"]
+     end
+
+     chef_environment = "vagrant"
+     chef_run_list = [ "recipe[packages]", "role[allinone-compute]" ]
+
+     # Ubuntu 12.04 Config
+     config.vm.define :ubuntu1204 do |ubuntu1204|
+       ubuntu1204.vm.hostname = "ubuntu1204"
+       ubuntu1204.vm.box = "opscode-ubuntu-12.04"
+       ubuntu1204.vm.box_url = "https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_ubuntu-12.04_provisionerless.box"
+       ubuntu1204.vm.provision :chef_client do |chef|
+         chef.environment = chef_environment
+         chef.run_list = chef_run_list.unshift("recipe[apt::cacher-client]")
+       end
+     end
+
+   end
+
+
+Environment
+-----------
+
+.. code-block:: ruby
+
+   name "vagrant"
+   description "Environment used in testing with Vagrant the upstream cookbooks and reference Chef repository. Defines the network and database settings to use with OpenStack. The networks will be used in the libraries provided by the osops-utils cookbook. This example is for FlatDHCP with 2 physical networks."
+
+   override_attributes(
+     "mysql" => {
+       "allow_remote_root" => true,
+       "root_network_acl" => "%"
+     },
+     "openstack" => {
+       "developer_mode" => true,
+       "identity" => {
+         "catalog" => {
+           "backend" => "templated"
+         },
+       },
+       "image" => {
+         "image_upload" => true,
+         "upload_images" => ["cirros"],
+         "upload_image" => {
+           "cirros" => "https://launchpad.net/cirros/trunk/0.3.0/+download/cirros-0.3.0-x86_64-disk.img"
+         },
+         "identity_service_chef_role" => "allinone-compute"
+       },
+       "block-storage" => {
+         "keystone_service_chef_role" => "allinone-compute"
+       },
+       "dashboard" => {
+         "keystone_service_chef_role" => "allinone-compute"
+       },
+       "network" => {
+         "rabbit_server_chef_role" => "allinone-compute"
+       },
+       "compute" => {
+         "identity_service_chef_role" => "allinone-compute",
+         "network" => {
+           "fixed_range" => "192.168.100.0/24",
+           "public_interface" => "eth2"
+         },
+         "config" => {
+           "ram_allocation_ratio" => 5.0
+         },
+         "libvirt" => {
+           "virt_type" => "qemu"
+         },
+         "networks" => [
+           {
+             "label" => "public",
+             "ipv4_cidr" => "192.168.100.0/24",
+             "num_networks" => "1",
+             "network_size" => "255",
+             "bridge" => "br100",
+             "bridge_dev" => "eth2",
+             "dns1" => "8.8.8.8",
+             "dns2" => "8.8.4.4"
+           }
+         ]
+       }
+     }
+   )
+
+Roles
+-----
+
+Vagrant Usage
+-------------
+
+$ vagrant up ubuntu1204HK
+$ vagrant ssh ubuntu1204HK
+6\. Check that the plugins are successfully installed:
+
+````shell
+$ vagrant plugin list
+  vagrant-berkshelf (1.3.4)
+  vagrant-chef-zero (0.5.0)
+  vagrant-omnibus (1.1.2)
+````
+
+7\. Install the Virtualbox image we will be using for the demo from one of the mirrors:
+
+````shell
+$ vagrant box add ubuntu1204HK http://RACKSPACE/HK_chef_openstack_ubuntu-12.04.box
+$ vagrant box add ubuntu1204HK http://192.168.1.10/HK_chef_openstack_ubuntu-12.04.box
+````
+
+8\. Start up the Vagrant virtual machine with the following command:
+
+````shell
+$ vagrant up ubuntu1204HK
+````
+
+9\. SSH into the Vagrant virtual machine once it has completed the installation:
+
+````shell
+$ vagrant ssh ubuntu1204HK
+````
+
+10\. Become the 'root' user:
+
+````shell
+$ sudo su -
+````
+
+11\. Source the `openrc` file to configure the `root` user's environment for OpenStack:
+
+````shell
+# source openrc
+````
+
+12\. List the Nova Compute services that are running:
+
+````shell
+# nova service-list
+````
+
+13\. List the Nova Compute hypervisors that are running:
+
+````shell
+# nova hypervisor-list
+````
+
+14\. List the Quantum Network services that are running:
+
+````shell
+# quantum agent-list
+````
+
+15\. Install the Cirros Linux base image from one of the mirrors:
+
+````shell
+# glance image-create --name cirros --is-public true --container-format bare --disk-format qcow2 --location http://RACKSPACE/cirros-0.3.0-x86_64-disk.img
+# glance image-create --name cirros --is-public true --container-format bare --disk-format qcow2 --location http://192.168.1.10/cirros-0.3.0-x86_64-disk.img
+# glance image-create --name cirros --is-public true --container-format bare --disk-format qcow2 --location https://launchpad.net/cirros/trunk/0.3.0/+download/cirros-0.3.0-x86_64-disk.img
+````
+
+16\. List the images available for creating instances:
+
+````shell
+# nova image-list
+````
+
+17\. Boot a very small test instance:
+
+````shell
+# nova boot test1 --image cirros --flavor 1 --poll
+````
+
+18\. List the instances that are currently running:
+
+````shell
+# nova list
+````
+
+19\. Inspect the running test instance:
+
+````shell
+# nova show test1
+````
+
+20\. SSH into the image, the user is 'cirros' and the password is 'cubswin:)':
+
+````shell
+root@ubuntu1204:~# ssh cirros@192.168.100.2
+The authenticity of host '192.168.100.2 (192.168.100.2)' can't be established.
+RSA key fingerprint is 90:c5:8c:9c:f7:73:b4:54:cf:15:0d:28:54:7f:e7:19.
+Are you sure you want to continue connecting (yes/no)? yes
+Warning: Permanently added '192.168.100.2' (RSA) to the list of known hosts.
+cirros@192.168.100.2's password:
+$
+````
+
+21\. Connect to the OpenStack Dashboard:
+
+````
+http://...:8443
+````
+
+22\. Logout of the instance and exit the Vagrant virtual machine. Destroy the Vagrant VM:
+
+````shell
+$ vagrant destroy ubuntu1204 -f
+````

--- a/includes_openstack/includes_openstack_repo_vagrant.rst
+++ b/includes_openstack/includes_openstack_repo_vagrant.rst
@@ -1,12 +1,12 @@
 .. The contents of this file are included in multiple topics.
 .. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
 
-[Vagrant](http://vagrantup.com) is a virtualization framework for managing development environments, it may be used for testing the :doc:`All-in-One </openstack_architecture_allinone>` configuration in the |chef repo openstack|. Vagrant is a third-party tool that may be used with |chef|, but is not required for using the |chef repo openstack|.
+**Vagrant** (https://vagrantup.com) is a virtualization framework for managing development environments, it may be used for testing the :doc:`All-in-One </openstack_architecture_allinone>` configuration in the |chef repo openstack|. Vagrant is an unsupported external third-party tool that may be used with |chef|, but is not required for using the |chef repo openstack|.
 
 Installation
 ------------
 
-Vagrant supports a number of virtualization and cloud back-ends. For our purposes we are using Virtualbox (currently 4.2.18). You may download it from Virtualbox.com.
+Vagrant supports a number of virtualization and cloud back-ends. For our purposes Virtualbox (https://www.virtualbox.org) is used.
 
 Install Vagrant 1.2.1 or later from packages. You may download it from https://downloads.vagrantup.com.
 
@@ -21,7 +21,7 @@ Our test configuration requires a number of Vagrant plugins, install the followi
 Vagrantfile
 -----------
 
-Vagrant uses a **Vagrantfile** for managing its configuration. Within the |chef repo openstack| there is a Vagrantfile that configures the Virtualbox VM for our purposes.
+Vagrant uses a **Vagrantfile** for managing its configuration. Within the |chef repo openstack| there is a Vagrantfile that configures the Virtualbox VM for our purposes. A few parts of that file are listed here:
 
 .. code-block:: ruby
 
@@ -40,11 +40,19 @@ Vagrant uses a **Vagrantfile** for managing its configuration. Within the |chef 
      # Omnibus plugin configuration
      config.omnibus.chef_version = :latest
 
+This is enabling and configuring the use of the Berkshelf, Chef Zero and Omnibus plugins for Vagrant.
+
+.. code-block:: ruby
+
      # Port forwarding rules, for access to openstack services
      config.vm.network "forwarded_port", guest: 443, host: 8443     # dashboard-ssl
      config.vm.network "forwarded_port", guest: 4000, host: 4000    # chef-zero
      config.vm.network "forwarded_port", guest: 8773, host: 8773    # compute-ec2-api
      config.vm.network "forwarded_port", guest: 8774, host: 8774    # compute-api
+
+This forwards ports from the Vagrant VM for accessing the OpenStack Dashboard and APIs. You may also access the Chef Zero installation with a custom knife.rb configuration file.
+
+.. code-block:: ruby
 
      # OpenStack-related settings
      config.vm.network "private_network", ip: "33.33.33.60"
@@ -56,8 +64,12 @@ Vagrant uses a **Vagrantfile** for managing its configuration. Within the |chef 
        vb.customize ["modifyvm", :id, "--nicpromisc3", "allow-all"]
      end
 
+This creates addtional network cards and networks for the Vagrant VM and increases the available memory and CPUs.
+
+.. code-block:: ruby
+
      chef_environment = "vagrant"
-     chef_run_list = [ "recipe[packages]", "role[allinone-compute]" ]
+     chef_run_list = [ "role[allinone-compute]" ]
 
      # Ubuntu 12.04 Config
      config.vm.define :ubuntu1204 do |ubuntu1204|
@@ -69,9 +81,9 @@ Vagrant uses a **Vagrantfile** for managing its configuration. Within the |chef 
          chef.run_list = chef_run_list.unshift("recipe[apt::cacher-client]")
        end
      end
-
    end
 
+Vagrant is configured to use the chef_client provisioner with the ``vagrant`` environment and the ``allinone-compute`` role for the ``run_list``. The Virtualbox images used are provided by the Opscode Bento project (https://github.com/opscode/bento).
 
 Environment
 -----------
@@ -138,124 +150,217 @@ Environment
      }
    )
 
-Roles
------
-
 Vagrant Usage
 -------------
 
-$ vagrant up ubuntu1204HK
-$ vagrant ssh ubuntu1204HK
-6\. Check that the plugins are successfully installed:
+From the |chef repo openstack|, launch the ``ubuntu1204`` VM with Vagrant. This will take several minutes as it does the ``chef-client`` run for the ``allinone-compute``.
 
-````shell
-$ vagrant plugin list
-  vagrant-berkshelf (1.3.4)
-  vagrant-chef-zero (0.5.0)
-  vagrant-omnibus (1.1.2)
-````
+.. code-block:: bash
 
-7\. Install the Virtualbox image we will be using for the demo from one of the mirrors:
+    $ vagrant up ubuntu1204
 
-````shell
-$ vagrant box add ubuntu1204HK http://RACKSPACE/HK_chef_openstack_ubuntu-12.04.box
-$ vagrant box add ubuntu1204HK http://192.168.1.10/HK_chef_openstack_ubuntu-12.04.box
-````
+SSH into the ``ubuntu1204`` VM with Vagrant.
 
-8\. Start up the Vagrant virtual machine with the following command:
+.. code-block:: bash
 
-````shell
-$ vagrant up ubuntu1204HK
-````
+    $ vagrant ssh ubuntu1204
+    Welcome to Ubuntu 12.04.2 LTS (GNU/Linux 3.5.0-23-generic x86_64)
 
-9\. SSH into the Vagrant virtual machine once it has completed the installation:
+     * Documentation:  https://help.ubuntu.com/
 
-````shell
-$ vagrant ssh ubuntu1204HK
-````
+    96 packages can be updated.
+    48 updates are security updates.
 
-10\. Become the 'root' user:
+    Last login: Sat May 11 05:55:03 2013 from 10.0.2.2
+    vagrant@ubuntu1204:~$
 
-````shell
-$ sudo su -
-````
+All commands after this are actually run from within the VM. ``sudo`` to the ``root`` user and source the ``openrc`` file to configure the shell environment for OpenStack.
 
-11\. Source the `openrc` file to configure the `root` user's environment for OpenStack:
+.. code-block:: bash
 
-````shell
-# source openrc
-````
+    vagrant@ubuntu1204:~$ sudo su -
+    root@ubuntu1204:~# source /root/openrc
 
-12\. List the Nova Compute services that are running:
+There are several basic checks that may be run to establish that the OpenStack deployment is operating properly. List the Nova Compute services that are running:
 
-````shell
-# nova service-list
-````
+.. code-block:: bash
 
-13\. List the Nova Compute hypervisors that are running:
+    root@ubuntu1204:~# nova service-list
+    +------------------+------------+----------+---------+-------+----------------------------+
+    | Binary           | Host       | Zone     | Status  | State | Updated_at                 |
+    +------------------+------------+----------+---------+-------+----------------------------+
+    | nova-cert        | ubuntu1204 | internal | enabled | up    | 2013-11-25T04:35:04.000000 |
+    | nova-compute     | ubuntu1204 | nova     | enabled | up    | 2013-11-25T04:35:07.000000 |
+    | nova-conductor   | ubuntu1204 | internal | enabled | up    | 2013-11-25T04:35:00.000000 |
+    | nova-consoleauth | ubuntu1204 | internal | enabled | up    | 2013-11-25T04:35:05.000000 |
+    | nova-network     | ubuntu1204 | internal | enabled | up    | 2013-11-25T04:35:07.000000 |
+    | nova-scheduler   | ubuntu1204 | internal | enabled | up    | 2013-11-25T04:35:00.000000 |
+    +------------------+------------+----------+---------+-------+----------------------------+
 
-````shell
-# nova hypervisor-list
-````
+.. List the Quantum Network services that are running:
+.. # quantum agent-list
+.. List the Nova Compute hypervisors that are running:
+.. # nova hypervisor-list
 
-14\. List the Quantum Network services that are running:
+Note that ``nova-network`` is listed, this will be updated soon and replaced by Quantum Network services. Next list the Identity catalog.
 
-````shell
-# quantum agent-list
-````
+.. code-block:: bash
 
-15\. Install the Cirros Linux base image from one of the mirrors:
+    root@ubuntu1204:~# keystone catalog
+    Service: compute
+    +-------------+-----------------------------------------------------------+
+    |   Property  |                           Value                           |
+    +-------------+-----------------------------------------------------------+
+    |   adminURL  | http://127.0.0.1:8774/v2/c32e2a09541648f7b6ab67475a88103b |
+    | internalURL | http://127.0.0.1:8774/v2/c32e2a09541648f7b6ab67475a88103b |
+    |  publicURL  | http://127.0.0.1:8774/v2/c32e2a09541648f7b6ab67475a88103b |
+    |    region   |                         RegionOne                         |
+    +-------------+-----------------------------------------------------------+
+    Service: network
+    +-------------+-----------------------+
+    |   Property  |         Value         |
+    +-------------+-----------------------+
+    |   adminURL  | http://127.0.0.1:9696 |
+    | internalURL | http://127.0.0.1:9696 |
+    |  publicURL  | http://127.0.0.1:9696 |
+    |    region   |       RegionOne       |
+    +-------------+-----------------------+
+    Service: image
+    +-------------+--------------------------+
+    |   Property  |          Value           |
+    +-------------+--------------------------+
+    |   adminURL  | http://127.0.0.1:9292/v2 |
+    | internalURL | http://127.0.0.1:9292/v2 |
+    |  publicURL  | http://127.0.0.1:9292/v2 |
+    |    region   |        RegionOne         |
+    +-------------+--------------------------+
+    Service: volume
+    +-------------+-----------------------------------------------------------+
+    |   Property  |                           Value                           |
+    +-------------+-----------------------------------------------------------+
+    |   adminURL  | http://127.0.0.1:8776/v1/c32e2a09541648f7b6ab67475a88103b |
+    | internalURL | http://127.0.0.1:8776/v1/c32e2a09541648f7b6ab67475a88103b |
+    |  publicURL  | http://127.0.0.1:8776/v1/c32e2a09541648f7b6ab67475a88103b |
+    |    region   |                         RegionOne                         |
+    +-------------+-----------------------------------------------------------+
+    Service: ec2
+    +-------------+--------------------------------------+
+    |   Property  |                Value                 |
+    +-------------+--------------------------------------+
+    |   adminURL  | http://127.0.0.1:8773/services/Cloud |
+    | internalURL | http://127.0.0.1:8773/services/Cloud |
+    |  publicURL  | http://127.0.0.1:8773/services/Cloud |
+    |    region   |              RegionOne               |
+    +-------------+--------------------------------------+
+    Service: identity
+    +-------------+-----------------------------+
+    |   Property  |            Value            |
+    +-------------+-----------------------------+
+    |   adminURL  | http://127.0.0.1:35357/v2.0 |
+    | internalURL |  http://127.0.0.1:5000/v2.0 |
+    |  publicURL  |  http://127.0.0.1:5000/v2.0 |
+    |    region   |          RegionOne          |
+    +-------------+-----------------------------+
 
-````shell
-# glance image-create --name cirros --is-public true --container-format bare --disk-format qcow2 --location http://RACKSPACE/cirros-0.3.0-x86_64-disk.img
-# glance image-create --name cirros --is-public true --container-format bare --disk-format qcow2 --location http://192.168.1.10/cirros-0.3.0-x86_64-disk.img
-# glance image-create --name cirros --is-public true --container-format bare --disk-format qcow2 --location https://launchpad.net/cirros/trunk/0.3.0/+download/cirros-0.3.0-x86_64-disk.img
-````
+List the images and favors of machines available for creating instances:
 
-16\. List the images available for creating instances:
+.. code-block:: bash
 
-````shell
-# nova image-list
-````
+    root@ubuntu1204:~# nova image-list
+    +--------------------------------------+--------+--------+--------+
+    | ID                                   | Name   | Status | Server |
+    +--------------------------------------+--------+--------+--------+
+    | 8dd388c2-0927-4c93-bafb-a9e132fe4526 | cirros | ACTIVE |        |
+    +--------------------------------------+--------+--------+--------+
+    root@ubuntu1204:~# nova flavor-list
+    +----+-----------+-----------+------+-----------+------+-------+-------------+-----------+-------------+
+    | ID | Name      | Memory_MB | Disk | Ephemeral | Swap | VCPUs | RXTX_Factor | Is_Public | extra_specs |
+    +----+-----------+-----------+------+-----------+------+-------+-------------+-----------+-------------+
+    | 1  | m1.tiny   | 512       | 0    | 0         |      | 1     | 1.0         | True      | {}          |
+    | 2  | m1.small  | 2048      | 20   | 0         |      | 1     | 1.0         | True      | {}          |
+    | 3  | m1.medium | 4096      | 40   | 0         |      | 2     | 1.0         | True      | {}          |
+    | 4  | m1.large  | 8192      | 80   | 0         |      | 4     | 1.0         | True      | {}          |
+    | 5  | m1.xlarge | 16384     | 160  | 0         |      | 8     | 1.0         | True      | {}          |
+    +----+-----------+-----------+------+-----------+------+-------+-------------+-----------+-------------+
 
-17\. Boot a very small test instance:
+The ``cirros`` Linux base image is installed during the installation because the `node['openstack']['image']['image_upload']` attribute is set to `true` in the `vagrant` Environment. Now create an instance named ``test1`` with the size of ``m1.tiny`` and image type of ``cirros`` (this will may take a few minutes).
 
-````shell
-# nova boot test1 --image cirros --flavor 1 --poll
-````
+.. code-block:: bash
 
-18\. List the instances that are currently running:
+    root@ubuntu1204:~# nova boot test1 --image cirros --flavor 1 --poll
+    +-------------------------------------+--------------------------------------+
+    | Property                            | Value                                |
+    +-------------------------------------+--------------------------------------+
+    | OS-EXT-STS:task_state               | scheduling                           |
+    | image                               | cirros                               |
+    | OS-EXT-STS:vm_state                 | building                             |
+    | OS-EXT-SRV-ATTR:instance_name       | instance-00000001                    |
+    | flavor                              | m1.tiny                              |
+    | id                                  | fd52d006-086f-4064-84e2-316684b03578 |
+    | security_groups                     | [{u'name': u'default'}]              |
+    | user_id                             | e2b2974738174924bc955c7441721894     |
+    | OS-DCF:diskConfig                   | MANUAL                               |
+    | accessIPv4                          |                                      |
+    | accessIPv6                          |                                      |
+    | progress                            | 0                                    |
+    | OS-EXT-STS:power_state              | 0                                    |
+    | OS-EXT-AZ:availability_zone         | nova                                 |
+    | config_drive                        |                                      |
+    | status                              | BUILD                                |
+    | updated                             | 2013-11-25T04:39:27Z                 |
+    | hostId                              |                                      |
+    | OS-EXT-SRV-ATTR:host                | None                                 |
+    | key_name                            | None                                 |
+    | OS-EXT-SRV-ATTR:hypervisor_hostname | None                                 |
+    | name                                | test1                                |
+    | adminPass                           | Uqa6u73rxngJ                         |
+    | tenant_id                           | c32e2a09541648f7b6ab67475a88103b     |
+    | created                             | 2013-11-25T04:39:27Z                 |
+    | metadata                            | {}                                   |
+    +-------------------------------------+--------------------------------------+
 
-````shell
-# nova list
-````
+    Instance building... 100% complete
+    Finished
 
-19\. Inspect the running test instance:
+The instance is now listed as ``ACTIVE``.
 
-````shell
-# nova show test1
-````
+.. code-block:: bash
 
-20\. SSH into the image, the user is 'cirros' and the password is 'cubswin:)':
+    root@ubuntu1204:~# nova list
+    +--------------------------------------+-------+--------+----------------------+
+    | ID                                   | Name  | Status | Networks             |
+    +--------------------------------------+-------+--------+----------------------+
+    | fd52d006-086f-4064-84e2-316684b03578 | test1 | ACTIVE | public=192.168.100.2 |
+    +--------------------------------------+-------+--------+----------------------+
 
-````shell
-root@ubuntu1204:~# ssh cirros@192.168.100.2
-The authenticity of host '192.168.100.2 (192.168.100.2)' can't be established.
-RSA key fingerprint is 90:c5:8c:9c:f7:73:b4:54:cf:15:0d:28:54:7f:e7:19.
-Are you sure you want to continue connecting (yes/no)? yes
-Warning: Permanently added '192.168.100.2' (RSA) to the list of known hosts.
-cirros@192.168.100.2's password:
-$
-````
+SSH into the instance with the user 'cirros' and the password 'cubswin:)':
 
-21\. Connect to the OpenStack Dashboard:
+.. code-block:: bash
 
-````
-http://...:8443
-````
+    root@ubuntu1204:~# ssh cirros@192.168.100.2
+    The authenticity of host '192.168.100.2 (192.168.100.2)' can't be established.
+    RSA key fingerprint is 72:6d:33:55:d9:2b:2b:dc:e8:c3:5a:e9:43:f5:0d:1a.
+    Are you sure you want to continue connecting (yes/no)? yes
+    Warning: Permanently added '192.168.100.2' (RSA) to the list of known hosts.
+    cirros@192.168.100.2's password:
+    $ uname -a
+    Linux cirros 3.0.0-12-virtual #20-Ubuntu SMP Fri Oct 7 18:19:02 UTC 2011 x86_64 GNU/Linux
+    $ exit
+    Connection to 192.168.100.2 closed.
 
-22\. Logout of the instance and exit the Vagrant virtual machine. Destroy the Vagrant VM:
+.. Depending on the IP address of your Vagrant instance, you may connect to the OpenStack Dashboard at http://...:8443
 
-````shell
-$ vagrant destroy ubuntu1204 -f
-````
+When you are finished with your testing, exit and destroy the Vagrant virtual machine:
+
+.. code-block:: bash
+
+    root@ubuntu1204:~# exit
+    logout
+    vagrant@ubuntu1204:~$ exit
+    logout
+    Connection to 127.0.0.1 closed.
+    $ vagrant destroy ubuntu1204 -f
+    [ubuntu1204] Forcing shutdown of VM...
+    [ubuntu1204] Destroying VM and associated drives...
+    [Chef Zero] Stopping Chef Zero
+    [ubuntu1204] Running cleanup tasks for 'chef_client' provisioner...


### PR DESCRIPTION
The Architecture page will eventually support many more configurations, so this page is being split now for the 2 existing ones. The Vagrant page fully fleshed-out and is linked from the All-in-One configuration and the Architecture main page.
