### PR TITLE
initial cut at opscode manage install docs

### DIFF
--- a/chef_master/source/index.rst
+++ b/chef_master/source/index.rst
@@ -220,6 +220,7 @@ Cookbooks
    handlers
    images
    install
+   install_manage
    install_push_jobs
    install_reporting
    junos

--- a/chef_master/source/install_manage.rst
+++ b/chef_master/source/install_manage.rst
@@ -1,0 +1,16 @@
+=====================================================
+Install |chef manager|
+=====================================================
+
+.. include:: ../../includes_install/includes_install_manage_overview.rst
+
+Requirements
+=====================================================
+.. include:: ../../includes_manage/includes_manage_requirements.rst
+
+|chef manager| Server
+=====================================================
+.. include:: ../../includes_install/includes_install_manage_server.rst
+
+
+

--- a/includes_install/includes_install_manage_overview.rst
+++ b/includes_install/includes_install_manage_overview.rst
@@ -1,0 +1,6 @@
+.. The contents of this file are included in multiple topics.
+.. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
+
+|chef manager| is installed on the same physical hardware as the |chef server oec| server
+(version 11.0.1 or higher).
+

--- a/includes_install/includes_install_manage_server.rst
+++ b/includes_install/includes_install_manage_server.rst
@@ -1,0 +1,42 @@
+.. The contents of this file are included in multiple topics.
+.. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
+
+To set up the |chef manager| server:
+
+#. Contact |opscode| and get the package that is appropriate for your |chef server oec| server's platform and operating system
+#. Install the package on the same machine that is running |chef server oec| 11.0.1 or higher. For example on |ubuntu|:
+
+   .. code-block:: bash
+
+      $ dpkg -i opscode-manage_1.0.0-1.ubuntu.10.04_amd64.deb
+
+#. Disable the legacy web interface:
+
+   Modify /etc/opscode/private-chef.rb to disable the existing opscode_webui service.
+
+   .. code-block:: bash
+
+      opscode_webui['enable']=false
+
+
+#. Reconfigure the |chef server oec| server:
+
+   .. code-block:: bash
+
+      $ private-chef-ctl reconfigure
+
+   This step is required for each of the front end servers in the Enterprise Chef deployment.  For
+   example, in a configuration with two back end servers and three front end servers, this command
+   would need to be run on all three front end machines.
+
+#. Reconfigure the |chef manager| server:
+
+   .. code-block:: bash
+
+      $ opscode-manage-ctl reconfigure
+
+   This step is required for each of the front end servers in the Enterprise Chef deployment.
+
+#. Verify the installation:
+
+   The |chef manager| should now be running and accessible by a web browser on port 443 (HTTPS)

--- a/includes_manage/includes_manage_requirements.rst
+++ b/includes_manage/includes_manage_requirements.rst
@@ -1,0 +1,9 @@
+.. The contents of this file are included in multiple topics.
+.. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
+
+
+|chef manager| has the following requirements:
+
+* |chef server oec| version 11.0.1 (or later)
+* The existing legacy |chef manager| must be disabled
+* TCP protocol ports 443


### PR DESCRIPTION
Docs for opscode manage installation

@jamescott I didn't link these in anywhere as we don't have a specific page for the management console add-on as opposed to the legacy webui1 console
