### PR TITLE
Correcting push jobs documentation

### DIFF
--- a/includes_config/includes_config_rb_push_jobs_server.rst
+++ b/includes_config/includes_config_rb_push_jobs_server.rst
@@ -1,4 +1,4 @@
 .. The contents of this file are included in multiple topics.
 .. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
 
-A |push_jobs_server rb| file is used to specify the configuration settings used by the |push jobs| server. This file is the default configuration file and is located at: ``/PATH/``.
+A |push_jobs_server rb| file is used to specify the configuration settings used by the |push jobs| server. This file is the default configuration file and is located at: ``/etc/opscode-push-jobs-server``.

--- a/includes_config/includes_config_rb_push_jobs_server_settings.rst
+++ b/includes_config/includes_config_rb_push_jobs_server_settings.rst
@@ -10,14 +10,14 @@ This configuration file has the following settings:
    * - Setting
      - Description
    * - ``api_port``
-     - The port used by the |api push jobs|.
+     - The port used by the |api push jobs|. Default: 10003
    * - ``command_port``
-     - The port on which a |push jobs| server listens for requests that are to be executed on managed nodes.
+     - The port on which a |push jobs| server listens for requests that are to be executed on managed nodes. Default: 10002
    * - ``heartbeat_interval``
-     - The frequency of the |push jobs| server heartbeat message.
+     - The frequency of the |push jobs| server heartbeat message. Default: 1000 (seconds)
    * - ``server_heartbeat_port``
-     - The port on which the |push jobs| server receives heartbeat messages from each |push jobs| client. (This port is the ``ROUTER`` half of the |zeromq| DEALER / ROUTER pattern.)
+     - The port on which the |push jobs| server receives heartbeat messages from each |push jobs| client. (This port is the ``ROUTER`` half of the |zeromq| DEALER / ROUTER pattern.) Default: 10000
    * - ``server_name``
      - The name of the |push jobs| server.
    * - ``zeromq_listen_address``
-     - The IP address used by |zeromq|.
+     - The IP address used by |zeromq|. Default: tcp://*


### PR DESCRIPTION
While setting up a trial of the Push Jobs Server I found there was missing information in the docs with respect to ports, etc. Feel free to clean up the formatting here but this is what I found.

The ports info should probably get pulled out into another doc (if there is one, I couldn't find it) since all the pedant tests wouldn't run without these ports being opened through the firewall. (Pedant will hit all the ports through the api_fqdn of the box.)
