### PR TITLE
data_bag_encrypt_version does not expect a string and will error out.

### DIFF
--- a/includes_config/includes_config_rb_11-4_knife_settings.rst
+++ b/includes_config/includes_config_rb_11-4_knife_settings.rst
@@ -28,7 +28,7 @@ This configuration file has the following settings:
      - The minimum required version of data bag encryption. Possible values: ``1`` or ``2``. When all of the machines in an organization are running |chef client| version 11.6 (or higher), it is recommended that this value be set to ``2``. For example:
        ::
  
-          data_bag_encrypt_version "2"
+          data_bag_encrypt_version 2
    * - ``cookbook_license``
      - |license|
    * - ``cookbook_path``

--- a/includes_config/includes_config_rb_11-6_knife_settings.rst
+++ b/includes_config/includes_config_rb_11-6_knife_settings.rst
@@ -38,7 +38,7 @@ This configuration file has the following settings:
      - The minimum required version of data bag encryption. Possible values: ``1`` or ``2``. When all of the machines in an organization are running |chef client| version 11.6 (or higher), it is recommended that this value be set to ``2``. For example:
        ::
  
-          data_bag_encrypt_version "2"   
+          data_bag_encrypt_version 2   
    * - ``node_name``
      - |name node| This is typically also the same name as the computer from which |knife| is run. For example:
        ::

--- a/includes_config/includes_config_rb_knife_settings.rst
+++ b/includes_config/includes_config_rb_knife_settings.rst
@@ -48,7 +48,7 @@ This configuration file has the following settings:
      - The minimum required version of data bag encryption. Possible values: ``1`` or ``2``. When all of the machines in an organization are running |chef client| version 11.6 (or higher), it is recommended that this value be set to ``2``. For example:
        ::
  
-          data_bag_encrypt_version "2"
+          data_bag_encrypt_version 2
    * - ``local_mode``
      - |local_mode| For example:
        ::


### PR DESCRIPTION
Removed the quotes around the value as they cause an error when used in knife.rb
