### PR TITLE
Fix swaps bugs and style problems

### DIFF
--- a/chef_master/translate/lwrp_webpi.pot
+++ b/chef_master/translate/lwrp_webpi.pot
@@ -38,7 +38,7 @@ msgstr ""
 
 #: ../../includes_lwrp/includes_lwrp_webpi_product.rst:4
 # 256cfd4251d44fdabc60a042ccf2e5f7
-msgid "The |lwrp webpi product| lightweight resource is used to automate and service installations for |windows azure| web roles using |microsoft webplcmdline|. For more information about |microsoft webplcmdline|, see: http://msdn.microsoft.com/en-us/library/windowsazure/gg433092.aspx."
+msgid "The |lwrp webpi product| lightweight resource is used to automate and service installations for |windows azure| web roles using |microsoft webpicmdline|. For more information about |microsoft webpicmdline|, see: http://msdn.microsoft.com/en-us/library/windowsazure/gg433092.aspx."
 msgstr ""
 
 #: ../source/lwrp_webpi.rst:18

--- a/chef_master/translate/windows.pot
+++ b/chef_master/translate/windows.pot
@@ -3892,7 +3892,7 @@ msgstr ""
 
 #: ../../includes_lwrp/includes_lwrp_webpi_product.rst:4
 # dc55b90d2c6e4e8f918994e7acf9def0
-msgid "The |lwrp webpi product| lightweight resource is used to automate and service installations for |windows azure| web roles using |microsoft webplcmdline|. For more information about |microsoft webplcmdline|, see: http://msdn.microsoft.com/en-us/library/windowsazure/gg433092.aspx."
+msgid "The |lwrp webpi product| lightweight resource is used to automate and service installations for |windows azure| web roles using |microsoft webpicmdline|. For more information about |microsoft webpicmdline|, see: http://msdn.microsoft.com/en-us/library/windowsazure/gg433092.aspx."
 msgstr ""
 
 #: ../source/windows.rst:635

--- a/includes_lwrp/includes_lwrp_webpi_product.rst
+++ b/includes_lwrp/includes_lwrp_webpi_product.rst
@@ -1,4 +1,4 @@
 .. The contents of this file are included in multiple topics.
 .. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
 
-The |lwrp webpi product| lightweight resource is used to automate and service installations for |windows azure| web roles using |microsoft webplcmdline|. For more information about |microsoft webplcmdline|, see: http://msdn.microsoft.com/en-us/library/windowsazure/gg433092.aspx.
+The |lwrp webpi product| lightweight resource is used to automate and service installations for |windows azure| web roles using |microsoft webpicmdline|. For more information about |microsoft webpicmdline|, see: http://msdn.microsoft.com/en-us/library/windowsazure/gg433092.aspx.

--- a/swaps/swap_names.txt
+++ b/swaps/swap_names.txt
@@ -50,7 +50,7 @@
 .. |chef pedant| replace:: chef-pedant
 .. |chef private| replace:: Private Chef
 .. |chef repo| replace:: chef-repo
-.. |chef repo openstack| replace:: Openstack chef-repo
+.. |chef repo openstack| replace:: OpenStack chef-repo
 .. |chef repo hidden| replace:: .chef
 .. |chef server| replace:: Chef server
 .. |chef server 10| replace:: Chef Server 0.10.x

--- a/swaps/swap_names.txt
+++ b/swaps/swap_names.txt
@@ -678,7 +678,7 @@
 .. |capistrano| replace:: Capistrano
 .. |celery| replace:: Celery
 .. |centos| replace:: CentOS
-.. |cfengine| replace:: Cfengine
+.. |cfengine| replace:: CFEngine
 .. |chmod| replace:: chmod
 .. |cisco asa| replace:: Cisco ASA
 .. |cisco ucs| replace:: Cisco UCS

--- a/swaps/swap_names.txt
+++ b/swaps/swap_names.txt
@@ -818,7 +818,7 @@
 .. |microsoft sqlserver| replace:: SQL Server
 .. |microsoft web deployment tool| replace:: Web Deployment Tool
 .. |microsoft webpi| replace:: Microsoft Web Platform Installer (WebPI)
-.. |microsoft webplcmdline| replace:: WebPlCmdLine.exe
+.. |microsoft webpicmdline| replace:: WebPICmdLine.exe
 .. |mint| replace:: Linux Mint
 .. |modphp| replace:: mod_php
 .. |moneta| replace:: Moneta

--- a/swaps/swap_names.txt
+++ b/swaps/swap_names.txt
@@ -979,7 +979,7 @@
 .. |virtualbox| replace:: VirtualBox
 .. |vlc| replace:: VLC media player
 .. |vmware| replace:: VMware
-.. |vmware fusion 5x| replace:: VMware Fusion 5x
+.. |vmware fusion 5x| replace:: VMware Fusion 5.x
 .. |voxel| replace:: Voxel
 .. |vrrp| replace:: VRRP
 .. |war| replace:: WAR

--- a/swaps/swap_names.txt
+++ b/swaps/swap_names.txt
@@ -779,8 +779,8 @@
 .. |js| replace:: JavaScript
 .. |json| replace:: JSON
 .. |juniper| replace:: Juniper Networks
-.. |juniper chef| replace:: Chef for Junos OS
-.. |junos| replace:: Junos OS
+.. |juniper chef| replace:: Chef for Junos 
+.. |junos| replace:: Junos
 .. |jvm| replace:: JVM
 .. |keepalived| replace:: Keepalived 
 .. |kerberos| replace:: Kerberos

--- a/swaps/swap_names.txt
+++ b/swaps/swap_names.txt
@@ -690,7 +690,7 @@
 .. |crond| replace:: cron.d
 .. |crond app| replace:: crond
 .. |crontab| replace:: crontab
-.. |csh| replace:: Csh
+.. |csh| replace:: csh
 .. |curl| replace:: cURL
 .. |daemontools| replace:: daemontools
 .. |darwin| replace:: Darwin


### PR DESCRIPTION
I'm proposing a series of fixes to the swaps, to correct capitalization and proper spelling of certain product names and technologies. I've created these as individual commits, so if you disagree with any, you can just cherry-pick the ones you like.

The most serious, of course, is the fact that WebPICmdLine is incorrectly written as "WebPlCmdLine" ("l" instead of capital "I" in the "PI". Hence all the downstream changes to .pot files.
