### PR TITLE
Remove link duplication from includes_chef_for_more_info.rst

### DIFF
--- a/includes_chef/includes_chef_for_more_info.rst
+++ b/includes_chef/includes_chef_for_more_info.rst
@@ -11,4 +11,4 @@ For more information about |company_name|, cookbooks, and the community:
 
 * |url opscode|
 * |url opscode_community|
-* |url opscode_cookbooks|
+* |url opscode_community_cookbooks|


### PR DESCRIPTION
Right now both opscode_community and opscode_cookbooks goes to http://community.opscode.com, this patch replaces second link with http://community.opscode.com/cookbooks.

Also there is rather misleading `|url opscode_cookbooks| replace:: http://community.opscode.com/` in swaps/swap_names.txt, maybe it should be changed to http://community.opscode.com/cookbooks instead.
