### PR TITLE
HelpSpot 16704 redux - Document all EC ports

### DIFF
--- a/includes_server_firewalls_and_ports/includes_server_firewalls_and_ports_be.rst
+++ b/includes_server_firewalls_and_ports/includes_server_firewalls_and_ports_be.rst
@@ -21,8 +21,6 @@ For back-end servers in an |chef server oec| installation:
      - |service nginx|
    * - 9683
      - |service nginx|
-   * - 9672
-     - |service nrpe|
    * - 5984
      - |service couchdb|
    * - 8983
@@ -31,7 +29,9 @@ For back-end servers in an |chef server oec| installation:
      - |service postgresql|
    * - 5672
      - |service rabbitmq|
-   * - 6379
-     - |service redis|
-   * - 7788
+   * - 16379
+     - |service redis_lb|
+   * - 4321
+     - |service bookshelf|
+   * - 7788-7799
      - |drbd|

--- a/includes_server_firewalls_and_ports/includes_server_firewalls_and_ports_fe.rst
+++ b/includes_server_firewalls_and_ports/includes_server_firewalls_and_ports_fe.rst
@@ -13,6 +13,4 @@ For front-end servers in an |chef server oec| installation:
      - |service nginx|
    * - 443
      - |service nginx|
-   * - 9672
-     - |service nrpe|
 

--- a/swaps/swap_names.txt
+++ b/swaps/swap_names.txt
@@ -392,7 +392,7 @@
 .. |service postgresql| replace:: **postgresql**
 .. |service push_jobs| replace:: **push_jobs**
 .. |service rabbitmq| replace:: **rabbitmq**
-.. |service redis| replace:: **redis**
+.. |service redis_lb| replace:: **redis_lb**
 .. |service reindexer| replace:: **opscode-expander-reindexer**
 .. |service reporting| replace:: **reporting**
 .. |service solr| replace:: **opscode-solr**


### PR DESCRIPTION
- Nagios and NRPE no longer exist in EC11
- Change redis to redis_lb (same service, new name)
- Add bookshelf service and port
- Document range of ports possible for DRBD kernel module
