### PR TITLE
Add docs for /universe API endpoint

### DIFF
--- a/chef_master/source/api_cookbooks_site.rst
+++ b/chef_master/source/api_cookbooks_site.rst
@@ -1,5 +1,5 @@
 =====================================================
-Cookbooks Site API 
+Cookbooks Site API
 =====================================================
 
 .. include:: ../../includes_api_cookbooks_site/includes_api_cookbooks_site.rst
@@ -61,3 +61,13 @@ GET
 GET
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 .. include:: ../../includes_api_cookbooks_site/includes_api_cookbooks_endpoint_search_get.rst
+
+
+/universe
+-----------------------------------------------------
+
+.. include:: ../../includes_api_cookbooks_site/includes_api_cookbooks_endpoint_universe.rst
+
+GET
++++++++++++++++++++++++++++++++++++++++++++++++++++++
+.. include:: ../../includes_api_cookbooks_site/includes_api_cookbooks_endpoint_universe_get.rst

--- a/includes_api_cookbooks_site/includes_api_cookbooks_endpoint_universe.rst
+++ b/includes_api_cookbooks_site/includes_api_cookbooks_endpoint_universe.rst
@@ -1,6 +1,7 @@
 .. The contents of this file are included in multiple topics.
 .. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
 
-Use the ``/universe`` endpoint to xxxxx.
+Use the ``/universe`` endpoint to retrieve a complete listing of cookbooks, versions, and dependencies
+for use inside the Berkshelf tool.
 
-The ``/universe`` endpoint has the following methods: ``XXXXX``, ``XXXXX``, ``XXXXX``.
+The ``/universe`` endpoint has the following methods: ``GET``.

--- a/includes_api_cookbooks_site/includes_api_cookbooks_endpoint_universe_get.rst
+++ b/includes_api_cookbooks_site/includes_api_cookbooks_endpoint_universe_get.rst
@@ -1,18 +1,7 @@
 .. The contents of this file are included in multiple topics.
 .. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
 
-The ``GET`` method is used to xxxxx.
-
-.. list-table::
-   :widths: 200 300
-   :header-rows: 1
-
-   * - Parameter
-     - Description
-   * - ``xxxxx``
-     - xxxxx
-   * - ``xxxxx``
-     - xxxxx
+The ``GET`` method is used to retrieve the universe data.
 
 This method has no parameters.
 
@@ -20,23 +9,46 @@ This method has no parameters.
 
 .. code-block:: xml
 
-   GET /universe/rest/of/endpoint
-
-Or:
-
-.. code-block:: xml
-
-   GET /universe/rest/of/endpoint
+   GET /universe
 
 **Response**
 
-The response will return xxxxx:
+The response will return an embedded hash, with the name of each cookbook as
+a top level key. Each cookbook will list out all of its versions, along with
+version specific information including a list of all its dependencies.
 
 .. code-block:: ruby
 
-  {
-    JSON
-  }
+   {
+     "ffmpeg": {
+       "0.1.0": {
+         "location_path": "http://supermarket.getchef.com/api/v1/cookbooks/ffmpeg/0.1.0/download"
+         "location_type": "supermarket",
+         "dependencies": {
+           "git": ">= 0.0.0",
+           "build-essential": ">= 0.0.0",
+           "libvpx": "~> 0.1.1",
+           "x264": "~> 0.1.1"
+         },
+       },
+       "0.1.1": {
+         "location_path": "http://supermarket.getchef.com/api/v1/cookbooks/ffmpeg/0.1.1/download"
+         "location_type": "supermarket",
+         "dependencies": {
+           "git": ">= 0.0.0",
+           "build-essential": ">= 0.0.0",
+           "libvpx": "~> 0.1.1",
+           "x264": "~> 0.1.1"
+         },
+       },
+      "pssh": {
+       "0.1.0": {
+         "location_path": "http://supermarket.getchef.com/api/v1/cookbooks/pssh.1.0/download"
+         "location_type": "supermarket",
+         "dependencies": {},
+       }
+     }
+   }
 
 .. list-table::
    :widths: 200 300
@@ -45,11 +57,4 @@ The response will return xxxxx:
    * - Response Code
      - Description
    * - ``200``
-     - |response code 200 ok| xxxxx.
-   * - ``400``
-     - |response code 400 unsuccessful| xxxxx. For example:
-       ::
-
-          {
-             JSON
-          }
+     - |response code 200 ok| One or more cookbooks and associated version information were returned.


### PR DESCRIPTION
This adds documentation for the `/universe` API endpoint, which is part of Supermarket.

This closes issue #281
