### PR TITLE
Update example's role.

### DIFF
--- a/chef_master/source/install_server_fe.rst
+++ b/chef_master/source/install_server_fe.rst
@@ -124,7 +124,7 @@ A completed |private chef rb| configuration file for a four server |chef server 
      - frontend
    * - chef.example.com
      - 192.168.4.5
-     - backend VIP
+     - load balanced frontend VIP
 
 Looks like this:
 


### PR DESCRIPTION
I think "chef.example.com"'s valid role is "load balanced front-end VIP".
Because I'm trying setup scaled Enterprise Chef server with referencing your docs also http://docs.opscode.com/install_server_be.html .
Please check it.
