### PR TITLE
Change ruby_block default action to :run

### DIFF
--- a/includes_resources/includes_resource_ruby_block_actions.rst
+++ b/includes_resources/includes_resource_ruby_block_actions.rst
@@ -9,5 +9,7 @@ This resource has the following actions:
 
    * - Action
      - Description
+   * - ``:run``
+     - Default. |resource action run ruby_block|
    * - ``:create``
-     - Default. |resource action create ruby_block|
+     - The same as ``:run``.

--- a/step_resource/step_resource_ruby_block_reload_configuration.rst
+++ b/step_resource/step_resource_ruby_block_reload_configuration.rst
@@ -25,7 +25,7 @@ The following example shows how to reload the configuration of a |chef client| u
        remote_file node[:ohai][:plugin_path] +"/#{plugin}" do
          source plugin
          owner "chef"
-		 notifies :create, "ruby_block[reload_config]", :immediately
+		 notifies :run, "ruby_block[reload_config]", :immediately
        end
      end
    end

--- a/step_resource/step_resource_ruby_block_reread_chef_client.rst
+++ b/step_resource/step_resource_ruby_block_reread_chef_client.rst
@@ -8,5 +8,5 @@
      block do
        Chef::Config.from_file("/etc/chef/client.rb")
      end
-     action :create
+     action :run
    end


### PR DESCRIPTION
The `ruby_block` default action is [`:run`](http://git.io/i5uAQg). `:create` is [just an alias](http://git.io/F2tMDQ).
