### PR TITLE
Fix redis_lb recipe per updated OC-11601

### DIFF
--- a/chef_master/source/upgrade_server_ha_notes.rst
+++ b/chef_master/source/upgrade_server_ha_notes.rst
@@ -390,7 +390,7 @@ Copy this file to ``/opt/opscode/embedded/cookbooks/private-chef/recipes/redis_l
       notifies :restart, 'service[redis_lb]', :immediately if is_data_master?
     end
     
-    service "redis_lb" do
+    runit_service "redis_lb" do
       action :start
       only_if { is_data_master? }
     end


### PR DESCRIPTION
As noted here: https://github.com/opscode/opscode-omnibus/commit/243c031442ab5e62ef54d9568d14a31b427016d2

Should use `runit_service` not `service`
