### PR TITLE
The initial feature of Chef Analytics is called Chef Actions (or actions...

### DIFF
--- a/includes_actions/includes_actions.rst
+++ b/includes_actions/includes_actions.rst
@@ -2,7 +2,7 @@
 .. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
 
 
-Actions are policy and administrative changes made to the |chef server|. The |chef server| gathers a lot of data—--each node object, the node run history for all nodes, the history of every cookbook and cookbook version, how policy settings, such as roles, environments, and data bags, are applied and to what they are applied, individual user data, and so on. Actions are changes to any of these objects. Actions can occur as the result of user interaction in the management console, as the result of knife commands, or by running the |chef client|. No matter what the source, all actions are tracked by the analytics platform and recorded in the action log. The result is real-time tracking with an intuitive display.
+Actions are policy and administrative changes made to the |chef server|. The |chef server| gathers a lot of data—--each node object, the node run history for all nodes, the history of every cookbook and cookbook version, how policy settings, such as roles, environments, and data bags, are applied and to what they are applied, individual user data, and so on. Actions are changes to any of these objects. Actions can occur as the result of user interaction in the management console, as the result of knife commands, or by running the |chef client|. No matter what the source, all actions are tracked by the analytics platform and recorded. The result is real-time tracking with an intuitive display.
 
 |chef actions| help you to answer the following questions:
 

--- a/step_actions_webui/step_actions_webui_search.rst
+++ b/step_actions_webui/step_actions_webui_search.rst
@@ -1,7 +1,7 @@
-.. This is an included how-to. 
+.. This is an included how-to.
 
 
-Actions can be searched by action log name. Use filters for entity name, entity type, action type, remote request identifier, and tag. Most filter fields auto-complete from a list of possible values. Use wildcard searches and data ranges to fine-tune search results.
+Actions can be searched by name. Use filters for entity name, entity type, action type, remote request identifier, and tag. Most filter fields auto-complete from a list of possible values. Use wildcard searches and data ranges to fine-tune search results.
 
 To search actions:
 
@@ -9,13 +9,13 @@ To search actions:
 #. Choose a filter. (Most filter fields will auto-complete with a list of possible values.)
 
    Use ``Action Type`` to filter for the type of action, such as create, update, or delete.
-   
+
    Use ``Entity Name`` to filter by |chef server| object name, such as cookbook, data bag, or role.
-   
+
    Use ``Entity Type`` to filter by |chef server| object type, such as client, cookbook version, or role.
-   
+
    Use ``Remote Request ID`` to filter by |chef client| run identifier that is reported back to |chef analytics| by |reporting|. This filter is useful for correlating actions that have occurred during specific |chef client| runs.
-   
+
    Use ``Tags`` to filter by user-defined tags. Each user agent that performs an action---|knife|, |berkshelf|, |chef client|, |chef manage|---is assigned a tag.
 
    .. image:: ../../images/step_actions_webui_search_filters.png

--- a/step_actions_webui/step_actions_webui_view_action_details.rst
+++ b/step_actions_webui/step_actions_webui_view_action_details.rst
@@ -1,11 +1,11 @@
-.. This is an included how-to. 
+.. This is an included how-to.
 
 
-The actions view always shows the most recent actions, including a one-line summary of what happend. For example: "Client dg created node - db a day ago." Each action in the view may be expanded to show action log details, including the name and request identifier of the |chef client| and the name of the |chef server oec| server instances involved in the action.
+The actions view always shows the most recent actions, including a one-line summary of what happend. For example: "Client dg created node - db a day ago." Each action in the view may be expanded to show action details, including the name and request identifier of the |chef client| and the name of the |chef server oec| server instances involved in the action.
 
-Every user in |chef analytics| has a picture that is associated with every action log entry that is created as a result of an action they perform. For the |chef client|, it's a picture of a computer screen (always). And for users, the images are fetched from gravatar.com, based on the email address associated with that user. If that user has uploaded a picture to gravatar.com, that picture will be used.
+Every user in |chef analytics| has a picture that is associated with the entry that is created as a result of an action they perform. For the |chef client|, it's a picture of a computer screen (always). And for users, the images are fetched from gravatar.com, based on the email address associated with that user. If that user has uploaded a picture to gravatar.com, that picture will be used.
 
-To view action log details:
+To view action details:
 
 #. Open |webui_analytics|.
 #. Choose an action and expand it.

--- a/swaps/swap_names.txt
+++ b/swaps/swap_names.txt
@@ -30,7 +30,7 @@
 .. |chef 11-10| replace:: Chef 11.10
 .. |chef 11-12| replace:: Chef 11.12
 .. |chef 11-14| replace:: Chef 11.14
-.. |chef actions| replace:: Chef Action Logs
+.. |chef actions| replace:: Chef Actions
 .. |chef api client| replace:: API client
 .. |chef analytics| replace:: Chef Analytics
 .. |chef analytics ctl| replace:: opscode-analytics-ctl


### PR DESCRIPTION
...).

We don't use the name 'Action Log' any more.
