### PR TITLE
Add docs for Supermarket's Users API.

### DIFF
--- a/chef_master/source/api_cookbooks_site.rst
+++ b/chef_master/source/api_cookbooks_site.rst
@@ -73,3 +73,13 @@ GET
 GET
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 .. include:: ../../includes_api_cookbooks_site/includes_api_cookbooks_endpoint_universe_get.rst
+
+
+/users/USERNAME
+-----------------------------------------------------
+
+.. include:: ../../includes_api_cookbooks_site/includes_api_cookbooks_endpoint_users.rst
+
+GET
++++++++++++++++++++++++++++++++++++++++++++++++++++++
+.. include:: ../../includes_api_cookbooks_site/includes_api_cookbooks_endpoint_users_get.rst

--- a/includes_api_cookbooks_site/includeS_api_cookbooks_endpoint_users_get.rst
+++ b/includes_api_cookbooks_site/includeS_api_cookbooks_endpoint_users_get.rst
@@ -1,0 +1,44 @@
+.. The contents of this file are included in multiple topics.
+.. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
+
+The ``GET`` method is used to get the details for a user.
+
+This method has no parameters.
+
+**Request**
+
+.. code-block:: xml
+
+   GET /users/USERNAME
+
+**Response**
+
+The response will return details for a user, including the Chef username of the user, the name of the user, the associated account details for the user, the cookbooks that user owns, the cookbooks that user collaborates on, and the cookbooks that user follows.
+
+.. code-block:: ruby
+
+   {
+     "username": "sethvargo",
+     "name": "Seth Vargo",
+     "company": "Chef Software, Inc",
+     "github": [
+       "sethvargo"
+     ],
+     "twitter": "sethvargo",
+     "irc": "sethvargo",
+     "jira": "sethvargo",
+     "cookbooks": {
+       "owns": {
+         "bacon": "https://supermarket.getchef/api/v1/cookbooks/bacon"
+         "chef-sugar": "https://supermarket.getchef/api/v1/cookbooks/chef-sugar"
+       },
+       "collaborates": {
+         "build-essential": "https://supermarket.getchef/api/v1/cookbooks/build-essential"
+         "jenkins": "https://supermarket.getchef/api/v1/cookbooks/jenkin"
+       },
+       "follows": {
+         "bacon": "https://supermarket.getchef/api/v1/cookbooks/bacon"
+         "chef-sugar": "https://supermarket.getchef/api/v1/cookbooks/chef-sugar"
+       }
+     }
+   }

--- a/includes_api_cookbooks_site/includes_api_cookbooks_endpoint_users.rst
+++ b/includes_api_cookbooks_site/includes_api_cookbooks_endpoint_users.rst
@@ -1,0 +1,4 @@
+.. The contents of this file are included in multiple topics.
+.. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
+
+The ``users/[USERNAME]`` endpoint allows a specific Supermarket user to be accessed. This endpoint has the following methods: ``GET``.


### PR DESCRIPTION
The Supermarket's Users API (/api/v1/users/USERNAME) returns information related
to the specified user.

The response example is only a sample of what is returned from sethvargo's user.

PR that adds the API: https://github.com/opscode/supermarket/pull/738
