### PR TITLE
fixed flawed source attribute

### DIFF
--- a/includes_resources/includes_resource_remote_directory_recursive_example.rst
+++ b/includes_resources/includes_resource_remote_directory_recursive_example.rst
@@ -44,7 +44,7 @@ The |resource remote_directory| resource can be used to build a website using th
      files_owner "yan"
      mode "0770"
      owner "hamilton"
-     source "/website"
+     source "website"
    end
 
 When the |chef client| runs, the |resource remote_directory| resource will tell the |chef client| to copy the directory tree from the cookbook to the file system using the structure defined in cookbook:


### PR DESCRIPTION
The source attribute in the remote_directory directive included a leading slash. This example does not work as written and was changed to reflect working behavior.
