### PR TITLE
Add documentation for the Supermarket read-only tools API.

### DIFF
--- a/chef_master/source/api_cookbooks_site.rst
+++ b/chef_master/source/api_cookbooks_site.rst
@@ -83,3 +83,30 @@ GET
 GET
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 .. include:: ../../includes_api_cookbooks_site/includes_api_cookbooks_endpoint_users_get.rst
+
+/tools
+-----------------------------------------------------
+
+.. include:: ../../includes_api_cookbooks_site/includes_api_cookbooks_endpoint_tools.rst
+
+GET
++++++++++++++++++++++++++++++++++++++++++++++++++++++
+.. include:: ../../includes_api_cookbooks_site/includes_api_cookbooks_endpoint_tools_get.rst
+
+/tools-search
+-----------------------------------------------------
+
+.. include:: ../../includes_api_cookbooks_site/includes_api_cookbooks_endpoint_tools_search.rst
+
+GET
++++++++++++++++++++++++++++++++++++++++++++++++++++++
+.. include:: ../../includes_api_cookbooks_site/includes_api_cookbooks_endpoint_tools_search_get.rst
+
+/tools/SLUG
+-----------------------------------------------------
+
+.. include:: ../../includes_api_cookbooks_site/includes_api_cookbooks_endpoint_tool_slug.rst
+
+GET
++++++++++++++++++++++++++++++++++++++++++++++++++++++
+.. include:: ../../includes_api_cookbooks_site/includes_api_cookbooks_endpoint_tool_slug_get.rst

--- a/includes_api_cookbooks_site/includes_api_cookbooks_endpoint_tool_slug.rst
+++ b/includes_api_cookbooks_site/includes_api_cookbooks_endpoint_tool_slug.rst
@@ -1,0 +1,4 @@
+.. The contents of this file are included in multiple topics.
+.. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
+
+The ``tools/[SLUG]`` endpoint allows a specific tool to be accessed. This endpoint has the following methods: ``GET``.

--- a/includes_api_cookbooks_site/includes_api_cookbooks_endpoint_tool_slug_get.rst
+++ b/includes_api_cookbooks_site/includes_api_cookbooks_endpoint_tool_slug_get.rst
@@ -1,0 +1,46 @@
+.. The contents of this file are included in multiple topics.
+.. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
+
+The ``GET`` method is used to get the details for a tool.
+
+This method has no parameters.
+
+**Request**
+
+.. code-block:: xml
+
+   GET /tools/TOOL_SLUG
+
+**Response**
+
+The response will return details for a tool, including the name of the tool, a type, description, owner, source URL and install instructions as markdown:
+
+.. code-block:: ruby
+
+    {
+      "name": "Berkshelf",
+      "slug": "berkshelf",
+      "type": "chef_tool",
+      "source_url": "https://github.com/berkshelf/berkshelf",
+      "description": "A Chef Cookbook manager",
+      "instructions": "# Berkshelf\r\n[![Gem Version](https://img.shields.io/gem/v/berkshelf.svg)][gem]\r\n[![Build Status](https://img.shields.io/travis/berkshelf/berkshelf.svg)][travis]\r\n\r\n[gem]: https://rubygems.org/gems/berkshelf\r\n[travis]: https://travis-ci.org/berkshelf/berkshelf\r\n\r\nManage a Cookbook or an Application's Cookbook dependencies\r\n\r\n## Installation\r\n\r\nBerkshelf is now included as part of the [Chef-DK](http://getchef.com/downloads/chef-dk). This is fastest, easiest, and the recommended installation method for getting up and running with Berkshelf.\r\n\r\n> note: You may need to uninstall the Berkshelf gem especially if you are using a Ruby version manager you may need to uninstall all Berkshelf gems from each Ruby installation.\r\n\r\n### From Rubygems\r\n\r\nIf you are a developer or you prefer to install from Rubygems, we've got you covered.\r\n\r\nAdd Berkshelf to your repository's `Gemfile`:\r\n\r\n```ruby\r\ngem 'berkshelf'\r\n```\r\n\r\nOr run it as a standalone:\r\n\r\n    $ gem install berkshelf\r\n\r\n## Usage\r\n\r\nSee [berkshelf.com](http://berkshelf.com) for up-to-date usage instructions.\r\n\r\n## Supported Platforms\r\n\r\nBerkshelf is tested on Ruby 1.9.3, 2.0, and 2.1.\r\n\r\nRuby 1.9 mode is required on all interpreters.\r\n\r\nRuby 1.9.1 and 1.9.2 are not officially supported. If you encounter problems, please upgrade to Ruby 2.0 or 1.9.3.\r\n\r\n## Configuration\r\n\r\nBerkshelf will search in specific locations for a configuration file. In order:\r\n\r\n    $PWD/.berkshelf/config.json\r\n    $PWD/berkshelf/config.json\r\n    $PWD/berkshelf-config.json\r\n    $PWD/config.json\r\n    ~/.berkshelf/config.json\r\n\r\nYou are encouraged to keep project-specific configuration in the `$PWD/.berkshelf` directory. A default configuration file is generated for you, but you can update the values to suit your needs.\r\n\r\n## Shell Completion\r\n\r\n- [Bash](https://github.com/berkshelf/berkshelf-bash-plugin)\r\n- [ZSH](https://github.com/berkshelf/berkshelf-zsh-plugin)\r\n\r\n## Plugins\r\n\r\nPlease see [Plugins page](https://github.com/berkshelf/berkshelf/blob/master/PLUGINS.md) for more information.\r\n\r\n## Getting Help\r\n\r\n* If you have an issue: report it on the [issue tracker](https://github.com/berkshelf/berkshelf/issues)\r\n* If you have a question: visit the #chef or #berkshelf channel on irc.freenode.net\r\n\r\n## Authors\r\n\r\n[The Berkshelf Core Team](https://github.com/berkshelf/berkshelf/wiki/Core-Team)\r\n\r\nThank you to all of our [Contributors](https://github.com/berkshelf/berkshelf/graphs/contributors), testers, and users.\r\n\r\nIf you'd like to contribute, please see our [contribution guidelines](https://github.com/berkshelf/berkshelf/blob/master/CONTRIBUTING.md) first.\r\n",
+      "owner": "reset"
+    }
+
+.. list-table::
+   :widths: 200 300
+   :header-rows: 1
+
+   * - Response Code
+     - Description
+   * - ``200``
+     - |response code 200 ok| The requested tool exists.
+   * - ``400``
+     - |response code 400 unsuccessful| The requested tool does not exist. For example:
+       ::
+
+          {
+             "error_messages":
+             ["Resource does not exist"],
+             "error_code": "NOT_FOUND"
+          }

--- a/includes_api_cookbooks_site/includes_api_cookbooks_endpoint_tools.rst
+++ b/includes_api_cookbooks_site/includes_api_cookbooks_endpoint_tools.rst
@@ -1,0 +1,4 @@
+.. The contents of this file are included in multiple topics.
+.. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
+
+The ``tools`` endpoint allows |supermarket| tools to be accessed. This endpoint has the following methods: ``GET``.

--- a/includes_api_cookbooks_site/includes_api_cookbooks_endpoint_tools_get.rst
+++ b/includes_api_cookbooks_site/includes_api_cookbooks_endpoint_tools_get.rst
@@ -1,0 +1,78 @@
+.. The contents of this file are included in multiple topics.
+.. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
+
+The ``GET`` method is used to get a listing of the available tools. Use the ``start`` and ``items`` parameters to set limits on the number of tools returned. Use the ``order`` parameter to change the way results are sorted.
+
+.. list-table::
+   :widths: 200 300
+   :header-rows: 1
+
+   * - Parameter
+     - Description
+   * - ``start``
+     - The offset into a list of tools, at which point the list of tools will begin.
+   * - ``items``
+     - The number of items to be returned as a result of the request.
+   * - ``order``
+     - A token specifying how to order results. Possible values: ``recently_added``.
+
+**Request**
+
+.. code-block:: xml
+
+   GET /tools?start=START&items=ITEMS
+   GET /tools?order=recently_added
+
+**Response**
+
+The response will return the name of the tool, a type, description, owner, source URL and URI. In addition, the total number of tools on |api cookbooks site| is shown, as well (if ``start`` is specified) the point at which the list of returned tools began:
+
+.. code-block:: ruby
+
+    {
+      "start": 0,
+      "total": 56,
+      "items": [
+        {
+          "tool_name": "Berkflow",
+          "tool_type": "chef_tool",
+          "tool_source_url": "https://github.com/reset/berkflow",
+          "tool_description": "A Cookbook-Centric Deployment workflow tool",
+          "tool_owner": "reset",
+          "tool": "https://supermarket.getchef.com/api/v1/tools/berkflow"
+        },
+        {
+          "tool_name": "Berkshelf",
+          "tool_type": "chef_tool",
+          "tool_source_url": "https://github.com/berkshelf/berkshelf",
+          "tool_description": "A Chef Cookbook manager",
+          "tool_owner": "reset",
+          "tool": "https://supermarket.getchef.com/api/v1/tools/berkshelf"
+        },
+        {
+          "tool_name": "Berkshelf-API",
+          "tool_type": "chef_tool",
+          "tool_source_url": "https://github.com/berkshelf/berkshelf-api",
+          "tool_description": "Berkshelf dependency API server",
+          "tool_owner": "reset",
+          "tool": "https://supermarket.getchef.com/api/v1/tools/berkshelf-api"
+        },
+        {
+          "tool_name": "ChefAPI",
+          "tool_type": "chef_tool",
+          "tool_source_url": "https://github.com/sethvargo/chef-api",
+          "tool_description": "ChefAPI is a dependency-minimal Ruby client for interacting with a Chef Server. It adopts many patterns and principles from Rails",
+          "tool_owner": "sethvargo",
+          "tool": "https://supermarket.getchef.com/api/v1/tools/chef-api"
+        }
+      ]
+    }
+
+.. list-table::
+   :widths: 200 300
+   :header-rows: 1
+
+   * - Response Code
+     - Description
+   * - ``200``
+     - |response code 200 ok| One or more tools were returned.

--- a/includes_api_cookbooks_site/includes_api_cookbooks_endpoint_tools_search.rst
+++ b/includes_api_cookbooks_site/includes_api_cookbooks_endpoint_tools_search.rst
@@ -1,0 +1,4 @@
+.. The contents of this file are included in multiple topics.
+.. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
+
+The ``tools`` endpoint allows |supermarket| tools to be searched. This endpoint has the following methods: ``GET``.

--- a/includes_api_cookbooks_site/includes_api_cookbooks_endpoint_tools_search_get.rst
+++ b/includes_api_cookbooks_site/includes_api_cookbooks_endpoint_tools_search_get.rst
@@ -1,0 +1,67 @@
+.. The contents of this file are included in multiple topics.
+.. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
+
+The ``GET`` method is used to get a list of tools that match a search query. Use the ``start`` and ``items`` parameters to set limits on the number of tools returned:
+
+.. list-table::
+   :widths: 200 300
+   :header-rows: 1
+
+   * - Parameter
+     - Description
+   * - ``q``
+     - |SEARCH_QUERY|
+   * - ``start``
+     - |start|
+   * - ``items``
+     - |rows|
+
+**Request**
+
+.. code-block:: xml
+
+   GET /tools-search?q=SEARCH_QUERY
+
+Or:
+
+.. code-block:: ruby
+
+   GET /tools-search?q=SEARCH_QUERY&start=START&items=ITEMS
+
+**Response**
+
+The response will return a list of tools that match the search query. Each returned data set will include the name of the tool, a type, description, owner, source URL and URI. In addition, the total number of tools that match the query on |api cookbooks site| is shown, as well (if ``start`` is specified) the point at which the list of returned tools began:
+
+.. code-block:: ruby
+
+    {
+      "start": 0,
+      "total": 2,
+      "items": [
+        {
+          "tool_name": "knife-spec",
+          "tool_type": "knife_plugin",
+          "tool_source_url": "https://github.com/sethvargo/knife-spec",
+          "tool_description": "knife-spec is a knife plugin that automatically generates Chef cookbook specs (tests) stubs for use with ChefSpec.",
+          "tool_owner": "sethvargo",
+          "tool": "https://supermarket.getchef.com/api/v1/tools/knife-spec"
+        },
+        {
+          "tool_name": "knife-rhn",
+          "tool_type": "knife_plugin",
+          "tool_source_url": "https://github.com/bflad/knife-rhn",
+          "tool_description": "Knife Plugin for Red Hat Network (RHN)",
+          "tool_owner": "bflad",
+          "tool": "https://supermarket.getchef.com/api/v1/tools/knife-rhn"
+        }
+      ]
+    }
+
+.. list-table::
+   :widths: 200 300
+   :header-rows: 1
+
+   * - Response Code
+     - Description
+   * - ``200``
+     - |response code 200 ok| One or more tools were returned as a result of the search query.


### PR DESCRIPTION
The Supermarket team has recently built out a read-only tools API, this adds documentation for it that is inline with the cookbooks API docs.
