### PR TITLE
Add documentation for Supermarkets cookbook version destroy endpoint

### DIFF
--- a/chef_master/source/api_cookbooks_site.rst
+++ b/chef_master/source/api_cookbooks_site.rst
@@ -46,6 +46,10 @@ GET
 
 .. include:: ../../includes_api_cookbooks_site/includes_api_cookbooks_endpoint_version.rst
 
+DELETE
++++++++++++++++++++++++++++++++++++++++++++++++++++++
+.. include:: ../../includes_api_cookbooks_site/includes_api_cookbooks_endpoint_version_delete.rst
+
 GET
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 .. include:: ../../includes_api_cookbooks_site/includes_api_cookbooks_endpoint_version_get.rst

--- a/includes_api_cookbooks_site/includes_api_cookbooks_endpoint_version.rst
+++ b/includes_api_cookbooks_site/includes_api_cookbooks_endpoint_version.rst
@@ -1,6 +1,6 @@
 .. The contents of this file are included in multiple topics.
 .. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
 
-A cookbook version always takes the form x.y.z, where x, y, and z are decimal numbers that are used to represent major (x), minor (y), and patch (z) versions. A two-part version (x.y) is also allowed. When passing a cookbook version using this method, underscores ("_") should be used as the separator between versions. For example, a cookbook with a version 1.0.1 would be 1_0_1. 
+A cookbook version always takes the form x.y.z, where x, y, and z are decimal numbers that are used to represent major (x), minor (y), and patch (z) versions. A two-part version (x.y) is also allowed. When passing a cookbook version using this method, underscores ("_") should be used as the separator between versions. For example, a cookbook with a version 1.0.1 would be 1_0_1.
 
-The ``/cookbooks/[VERSION]`` endpoint has the following methods: ``GET``.
+The ``/cookbooks/[VERSION]`` endpoint has the following methods: ``DELETE`` and ``GET``.

--- a/includes_api_cookbooks_site/includes_api_cookbooks_endpoint_version_delete.rst
+++ b/includes_api_cookbooks_site/includes_api_cookbooks_endpoint_version_delete.rst
@@ -1,0 +1,55 @@
+.. The contents of this file are included in multiple topics.
+.. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
+
+The ``DELETE`` method is used to delete a cookbook version.
+
+This method has no parameters.
+
+**Request**
+
+.. code-block:: xml
+
+   DELETE /cookbooks/cookbook_name/versions/version
+
+**Response**
+
+The response will return something like the following:
+
+.. code-block:: ruby
+
+  {
+    "license": "Apache 2.0",
+    "tarball_file_size": 18553,
+    "version": "2.4.0",
+    "average_rating": null,
+    "cookbook": "http://supermarket.getchef.com/api/v1/cookbooks/apt",
+    "file": "http://supermarket.getchef.com/api/v1/cookbooks/apt/versions/2_4_0/download",
+    "dependencies": {},
+    "platforms": {
+      "debian": ">= 0.0.0",
+      "ubuntu": ">= 0.0.0"
+    }
+  }
+
+.. list-table::
+   :widths: 200 300
+   :header-rows: 1
+
+   * - Response Code
+     - Description
+   * - ``200``
+     - |response code 200 ok| The cookbook version was deleted.
+   * - ``400``
+     - |response code 400 unsuccessful| The requested cookbook or cookbook version does not exist. For example:
+       ::
+
+          {
+             "error_messages":
+             ["Resource does not exist"],
+             "error_code": "NOT_FOUND"
+          }
+   * - ``403``
+     - |response code 403 unauthorized| The user is not authorized to delete the cookbook version. For example:
+       ::
+
+          {}


### PR DESCRIPTION
The Supermarket API [now supports destroying a single cookbook version](https://github.com/opscode/supermarket/issues/583), this documents how to use it.
