### PR TITLE
typo use_inline_resoures => use_inline_resources

### DIFF
--- a/includes_dsl_provider/includes_dsl_provider_method_use_inline_resources.rst
+++ b/includes_dsl_provider/includes_dsl_provider_method_use_inline_resources.rst
@@ -6,7 +6,7 @@ A lightweight resource should be set to inline compile mode by adding the ``use_
 
 .. code-block:: ruby
 
-   use_inline_resoures
+   use_inline_resources
 
    action :run do
      # Ruby code that implements the provider


### PR DESCRIPTION
typo fix for http://docs.getchef.com/lwrp_custom_provider.html#use-inline-resources
