### PR TITLE
CHEF-2730 explain what flush_cache in yum actually does.

### DIFF
--- a/swaps/swap_descriptions.txt
+++ b/swaps/swap_descriptions.txt
@@ -393,7 +393,7 @@
 .. |flags| replace:: One (or more) command line flags that are passed to the interpreter when a command is invoked.
 .. |flat| replace:: Use to show a list of file names. Set to ``false`` to view ls-like output.
 .. |flavor| replace:: The name of the flavor that identifies the hardware configuration of the server, including disk space, memory capacity, and CPU priority.
-.. |flush_cache| replace:: Use to flush the |yum| cache before or after a |yum| operation that installs, upgrades, or removes a package. Possible values: ``:before`` or ``:after``.
+.. |flush_cache| replace:: Use to flush the |yum| cache before or after a |yum| operation that installs, upgrades, or removes a package. Possible values: ``:before`` or ``:after``. Note: this is not the |yum| command's cache, it is Chef's cache of the |yum| database on the machine. It is not the same as performing a 'yum clean all'.
 .. |force| replace:: Use to force the download of a deprecated cookbook.
 .. |force directory| replace:: Use to overwrite an existing directory.
 .. |force knife download| replace:: Use ``--force`` to download files even when the file on the hard drive is identical to the object on the server (role, cookbook, etc.). By default, files are compared to see if they have equivalent content, and local files are only overwritten if they are different.


### PR DESCRIPTION
The documentation for flush_cache was misleading, and many assumed it ran
'yum clean all' as apposed to actually discarding chef's yum-dump.py
output. This expels that myth and should stop others thinking the same.

See https://github.com/opscode/chef/commit/5268746fee205eb40e96a2437172580fe8ac3fee for a bit more details.
