### PR TITLE
Fixed the Learn Chef links to not point to legacy.

### DIFF
--- a/includes_chef/includes_chef_index_learnchef.rst
+++ b/includes_chef/includes_chef_index_learnchef.rst
@@ -2,7 +2,7 @@
 .. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
 
 
-**learn.getchef.com:**  `Learn Chef <http://learn.getchef.com>`_ | `Get started <http://learn.getchef.com/get-started>`_ | `Create your first cookbook <http://learn.getchef.com/tutorials/create-your-first-cookbook>`_
+**Learn Chef:**  `Get started <http://learn.getchef.com/>`_
 
 
 


### PR DESCRIPTION
I edited this a bit to:
- Not point to legacy links
- Make the bolded bullet title "Learn Chef" since that's what this actually is
