### PR TITLE
Add ports and further docs for EC11 and Chef 12

### DIFF
--- a/includes_server_firewalls_and_ports/includes_server_firewalls_and_ports_be.rst
+++ b/includes_server_firewalls_and_ports/includes_server_firewalls_and_ports_be.rst
@@ -4,36 +4,33 @@
 For back-end servers in an |chef server| installation:
 
 .. list-table::
-   :widths: 60 420
+   :widths: 60 420 60
    :header-rows: 1
 
    * - Port
      - Service
-   * - 80
-     - |service nginx|
-   * - 443
-     - |service nginx|
-   * - 9463
-     - |service bifrost|
-   * - 9671
-     - |service nginx|
-   * - 9680
-     - |service nginx|
-   * - 9685
-     - |service nginx|
-   * - 9683
-     - |service nginx|
+     - External
+   * - 5984
+     - |service couchdb|
+     - yes
    * - 8983
-     - |service solr|
+     - |service solr| or |service solr4|
+     - yes
    * - 5432
      - |service postgresql|
+     - yes
    * - 5672
      - |service rabbitmq|
+     - yes
    * - 16379
      - |service redis_lb|
+     - yes
    * - 4321
      - |service bookshelf|
+     - yes
+   * - 4369
+     - |service orgcreator|
+     - no
    * - 7788-7799
      - |drbd| This port range must be open between all back end servers.
-   * - 8000
-     - |service erchef|
+     - no

--- a/includes_server_firewalls_and_ports/includes_server_firewalls_and_ports_fe.rst
+++ b/includes_server_firewalls_and_ports/includes_server_firewalls_and_ports_fe.rst
@@ -4,13 +4,42 @@
 For front-end servers in an |chef server| installation:
 
 .. list-table::
-   :widths: 60 420
+   :widths: 60 420 60
    :header-rows: 1
 
    * - Port
      - Service
+     - External
    * - 80
      - |service nginx|
+     - yes
    * - 443
      - |service nginx|
-
+     - yes
+   * - 8000
+     - |service erchef|
+     - no
+   * - 5140
+     - |service certificate|
+     - no
+   * - 9462
+     - |service webui|
+     - no
+   * - 9090
+     - |service ocid|
+     - no
+   * - 9465
+     - |service account|
+     - no
+   * - 9463
+     - |service bifrost|
+     - no
+   * - 9680
+     - |api chef server| internal LB port
+     - no
+   * - 9685
+     - |service account| internal LB port
+     - no
+   * - 9683
+     - |service bifrost| internal LB port
+     - no

--- a/includes_server_firewalls_and_ports/includes_server_firewalls_and_ports_loopback.rst
+++ b/includes_server_firewalls_and_ports/includes_server_firewalls_and_ports_loopback.rst
@@ -1,6 +1,5 @@
 .. The contents of this file are included in multiple topics.
 .. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
 
-A single loopback interface should be configured using the ``127.0.0.1`` address. This ensures that all of the services are available to the |chef server|, in the event that the |chef server| attempts to contact itself from within a front or back end machine.
-
+A single loopback interface should be configured using the ``127.0.0.1`` address. This ensures that all of the services are available to the |chef server|, in the event that the |chef server| attempts to contact itself from within a machine. For proper functioning, all of the ports listed should be accessible through the loopback interface.
 

--- a/swaps/swap_names.txt
+++ b/swaps/swap_names.txt
@@ -444,6 +444,7 @@
 .. |service reindexer| replace:: **opscode-expander-reindexer**
 .. |service reporting| replace:: **reporting**
 .. |service solr| replace:: **opscode-solr**
+.. |service solr4| replace:: **opscode-solr4**
 .. |service webui| replace:: **opscode-webui**
 
 .. Chef Analytics services


### PR DESCRIPTION
- Some of the EC11 docs point here, so adding some info that doesn't actually exist in Chef 12.
  Opening a few additional ports with nothing on them will be fine.
- Be more precise about the services usage of loopback
