### PR TITLE
Fix deploy_revision typo in deploy_branch docs

### DIFF
--- a/includes_resources/includes_resource_deploy_providers_deploy_branch.rst
+++ b/includes_resources/includes_resource_deploy_providers_deploy_branch.rst
@@ -2,4 +2,4 @@
 .. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
 
 
-The ``deploy_branch`` resource is used in the same way as the ``deploy_resource`` resource. It uses the ``Deploy::Revision`` provider and has uses the same set of actions and attributes.
+The ``deploy_branch`` resource is used in the same way as the ``deploy_revision`` resource. It uses the ``Deploy::Revision`` provider and has uses the same set of actions and attributes.

--- a/includes_resources/includes_resource_deploy_providers_deploy_branch.rst
+++ b/includes_resources/includes_resource_deploy_providers_deploy_branch.rst
@@ -2,4 +2,4 @@
 .. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
 
 
-The ``deploy_branch`` resource is used in the same way as the ``deploy_revision`` resource. It uses the ``Deploy::Revision`` provider and has uses the same set of actions and attributes.
+The ``deploy_branch`` resource is used in the same way as the ``deploy_revision`` resource. It uses the ``Deploy::Revision`` provider and has the same set of actions and attributes.


### PR DESCRIPTION
I think this was just a simple typo and it should be called `deploy_revision` instead of `deploy_resource`.
