### PR TITLE
bffcreate is used to create BFFs, not to install them.

### DIFF
--- a/release_chef_12-0/includes_resource_package_bff.rst
+++ b/release_chef_12-0/includes_resource_package_bff.rst
@@ -1,4 +1,4 @@
 .. The contents of this file are included in multiple topics.
 .. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
 
-Use the |resource package_bff| resource to manage packages for the |ibm aix| platform using the |ibm bffcreate| utility. When a package is installed from a local file, it must be added to the node using the |resource remote_file| or |resource cookbook_file| resources.
+Use the |resource package_bff| resource to manage packages for the |ibm aix| platform using the |ibm installp| utility. When a package is installed from a local file, it must be added to the node using the |resource remote_file| or |resource cookbook_file| resources.

--- a/swaps/swap_names.txt
+++ b/swaps/swap_names.txt
@@ -807,6 +807,7 @@
 .. |ibm aix_bff| replace:: Backup File Format (BFF)
 .. |ibm aix_src| replace:: System Resource Controller (SRC)
 .. |ibm bffcreate| replace:: bffcreate
+.. |ibm installp| replace:: installp
 .. |icmp| replace:: ICMP
 .. |ifconfig| replace:: ifconfig
 .. |if_modified_since| replace:: If-Modified-Since


### PR DESCRIPTION
End-users don't generally don't touch bffcreate unless they are packaging software. `installp` is used to install things on AIX.
