### PR TITLE
Document how to switch to new master under chef-sync

### DIFF
--- a/includes_install/includes_install_server_replication.rst
+++ b/includes_install/includes_install_server_replication.rst
@@ -1,7 +1,7 @@
 .. The contents of this file may be included in multiple topics.
 .. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
 
-To configure replication of |chef server| data, first install |chef replication|, then configure the master |chef server|, then configure the replica |chef server|, and then start the synchronization process. 
+To configure replication of |chef server| data, first install |chef replication| on the master |chef server| and all replica |chef servers|, then configure the master |chef server|, then configure the replica |chef server|, and then start the synchronization process.
 
 #. To install |chef replication|, run the following on all machines in the |chef server| configuration. For |debian dpkg|:
 

--- a/includes_install/includes_install_server_replication_new_master.rst
+++ b/includes_install/includes_install_server_replication_new_master.rst
@@ -1,0 +1,63 @@
+.. The contents of this file may be included in multiple topics.
+.. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
+
+To configure replication from a new master, first make sure all replicas are up-to-date from the master, then stop the original master |chef server|, then configure the new master |chef server|, then configure each replica |chef server|. This may be necessary for DR/BC scenarios. 
+
+Note that |chef replication| does not yet support a complete re-synchronization from master to replica, so if the original master had changes that did not propagate to all replicas, then you may have inconsistent policies across your |chef servers|.
+
+#. On the new master |chef server|, run the following command:
+  
+   .. code-block:: bash
+      
+      $ chef-sync-ctl stop
+
+#. On the new master |chef server|, create the |chef_sync rb| file in the ``/etc/chef-sync/`` directory, and then add the following setting:
+
+   .. code-block:: ruby
+      
+      role :master
+
+#. On the new master |chef server|, run the following command:
+  
+   .. code-block:: bash
+      
+      $ chef-sync-ctl reconfigure
+
+#. On the new master |chef server|, run the following command:
+  
+   .. code-block:: bash
+      
+      $ chef-server-ctl reconfigure
+
+#. On the new master |chef server|, run the following command for each source organization (SOURCE_ORG_NAME)
+
+   .. code-block:: bash
+      
+      $ chef-sync-ctl prepare-org SOURCE_ORG_NAME
+
+#. For each replica |chef server|, move the ``/etc/chef-sync/ec_sync_user.pem`` file from the new master |chef server| to the ``/etc/chef-sync`` directory on the replica. (This file is created automatically on the master |chef server|.)
+
+#. For each replica |chef server|, create the |chef_sync rb| file in the ``/etc/chef-sync/`` directory, and then add the following setting:
+
+   .. code-block:: ruby
+      
+      role :replica
+      master "https://FQDN_OF_NEW_MASTER"
+
+#. For each replica |chef server|, run the following command:
+  
+   .. code-block:: bash
+      
+      $ chef-sync-ctl reconfigure
+
+#. For each replica |chef server|, run the following command:
+
+   .. code-block:: bash
+      
+      $ chef-sync-ctl prepare-org DEST_ORG_NAME
+
+#. For each replica |chef server|, run the following command:
+  
+   .. code-block:: bash
+      
+      $ chef-server-ctl reconfigure

--- a/includes_server_replication/includes_server_replication_scenarios.rst
+++ b/includes_server_replication/includes_server_replication_scenarios.rst
@@ -11,8 +11,13 @@ and for example, a single primary |chef server| and multiple replicas:
 
 .. image:: ../../images/chef_server_replication_many.png
 
+|chef replication| use cases:
+
+* Distributing glocal policy across multiple datacenters, and distributing traffic across |chef servers|
+* Reducing wide-area network traffic by pointing clients to the nearest replica |chef server|
+* Daisy-chain policy distribution from master to replica, and from replica to another replica
+
 |chef replication| should not be used for:
 
-* Disaster recovery or backup/restore processes. The replication process is read-only and cannot be changed to read-write
-* Synchronizing a replica instance with another replica instance
+* Automated disaster recovery or backup/restore processes. The replication process is read-only and cannot be changed to read-write without manual intervention
 * Node re-registration. A node may be associated only with a single |chef server|

--- a/includes_server_replication/includes_server_replication_scenarios.rst
+++ b/includes_server_replication/includes_server_replication_scenarios.rst
@@ -15,7 +15,8 @@ and for example, a single primary |chef server| and multiple replicas:
 
 * Distributing glocal policy across multiple datacenters, and distributing traffic across |chef servers|
 * Reducing wide-area network traffic by pointing clients to the nearest replica |chef server|
-* Daisy-chain policy distribution from master to replica, and from replica to another replica
+* Business continuity in the event of an unavailable primary data center (and its |chef server|)
+* Synchronizing a replica instance with another replica instance
 
 |chef replication| should not be used for:
 


### PR DESCRIPTION
This is a WIP since I have not tested the steps below. I would love help from @stevendanna or @scotthain or others familiar with replication that the steps in `/includes_install_server_replication_new_master.rst` seem about right before I go off and test it.

Also, I've heard that replica to replica sync is feasible, so updated scenarios (and added use cases). Let me know if that needs testing.

Thanks,

--Peter
