### PR TITLE
Update lb redis_connection_timeout to current default value

### DIFF
--- a/includes_config/includes_config_rb_chef_server_enterprise_settings_load_balancer.rst
+++ b/includes_config/includes_config_rb_chef_server_enterprise_settings_load_balancer.rst
@@ -37,7 +37,7 @@ This configuration file has the following settings for load balancers:
    * - ``lb['redis_connection_pool_size']``
      - Default value: ``250``.
    * - ``lb['redis_connection_timeout']``
-     - Default value: ``60``.
+     - Default value: ``1000``.
    * - ``lb['redis_keepalive_timeout']``
      - Default value: ``2000``.
    * - ``lb['upstream']``


### PR DESCRIPTION
Current setting for 11.1.x and 11.2.x https://github.com/opscode/opscode-omnibus/blob/11.1-stable/files/private-chef-cookbooks/private-chef/attributes/default.rb#L267
