### PR TITLE
Fixing ChefDK mac uninstall command

### DIFF
--- a/includes_install/includes_install_chef_dk_uninstall_mac.rst
+++ b/includes_install/includes_install_chef_dk_uninstall_mac.rst
@@ -19,4 +19,4 @@ To remove the symlinks under ``/usr/bin``:
 
 .. code-block:: bash
 
-   $ ls -la /usr/bin | egrep '/opt/chefdk' | awk '{ print $9 }' | sudo xargs -I % rm -f /usr/bin/%
+   $ find /usr/bin -lname '/opt/chefdk/*' -delete


### PR DESCRIPTION
This is related to https://github.com/opscode/chef-dk/issues/248. Someone's `ls` output had an additional column that was preventing the parsing from working correctly. Rather than relying on [parsing `ls` correctly](http://mywiki.wooledge.org/ParsingLs), how about we use `find` to do everything in one command.
