### PR TITLE
Update openstack testing workflow

### DIFF
--- a/includes_openstack/includes_openstack_cookbooks_test.rst
+++ b/includes_openstack/includes_openstack_cookbooks_test.rst
@@ -1,12 +1,12 @@
 .. The contents of this file are included in multiple topics.
 .. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
 
-Cookbook testing uses `bundler <http://gembundler.com/>`_, `Berkshelf <http://berkshelf.com/>`_, and `strainer <https://github.com/customink/strainer>`_ to isolate dependencies and run tests. Tests are defined using a Strainerfile and StackForge's Jenkins gates on them.
+Cookbook testing uses `bundler <http://gembundler.com/>`_, `Berkshelf <http://berkshelf.com/>`_, and `Rake <https://github.com/ruby/rake>`_ to run tests. Tests are defined using a Rakefile and StackForge's Jenkins gates on them.
 
 To run tests from the cookbook directory:
 
 .. code-block:: bash
 
    $ bundle install --path=.bundle # install gem dependencies
-   $ bundle exec berks install --path=.cookbooks # install cookbook dependencies
-   $ bundle exec strainer test -s Strainerfile # run tests
+   $ bundle exec berks vendor .cookbooks # install cookbook dependencies
+   $ bundle exec rake e # run tests


### PR DESCRIPTION
Openstack use berkshelf 3 and `berks install --path` don't working anymore, use `berks vendor` instead.
Strainer is no longer used and a Rakefile have been added to make the job, the default command for testing lint, style and unit is `bundle exec rake`.
