### PR TITLE
Change grizzly to juno for openstack cookbooks

### DIFF
--- a/chef_master/translate/openstack_cookbooks.pot
+++ b/chef_master/translate/openstack_cookbooks.pot
@@ -88,7 +88,7 @@ msgstr ""
 
 #: ../../includes_openstack/includes_openstack_cookbooks_common.rst:4
 # 9b8d23e60ea244528a6638d27a9355b0
-msgid "Installs common setup recipes, helper methods, and attributes for use with |openstack grizzly| and |openstack chef|."
+msgid "Installs common setup recipes, helper methods, and attributes for use with |openstack juno| and |openstack chef|."
 msgstr ""
 
 #: ../../includes_openstack/includes_openstack_cookbooks_common.rst:6
@@ -208,7 +208,7 @@ msgstr ""
 
 #: ../../includes_openstack/includes_openstack_cookbooks_ops_database.rst:5
 # 52cfd393c0f64d1c9f050a03e52f3cde
-msgid "Installs a reference database configuration for use with |openstack grizzly| and |openstack chef|. This cookbook is not required and alternate database configurations may be used. Supported databases: |mysql| (and will support |postgresql| soon)."
+msgid "Installs a reference database configuration for use with |openstack juno| and |openstack chef|. This cookbook is not required and alternate database configurations may be used. Supported databases: |mysql| and |postgresql|."
 msgstr ""
 
 #: ../../includes_openstack/includes_openstack_cookbooks_ops_database.rst:7
@@ -223,7 +223,7 @@ msgstr ""
 
 #: ../../includes_openstack/includes_openstack_cookbooks_ops_messaging.rst:5
 # e9ebec74565c4420b7ecbc41113461a7
-msgid "Installs a shared message queue for use with |openstack grizzly| and |openstack chef|. This cookbook is not required and alternate messaging services may be used. Supported message services: |rabbitmq|."
+msgid "Installs a shared message queue for use with |openstack juno| and |openstack chef|. This cookbook is not required and alternate messaging services may be used. Supported message services: |rabbitmq|."
 msgstr ""
 
 #: ../../includes_openstack/includes_openstack_cookbooks_ops_messaging.rst:7
@@ -305,4 +305,3 @@ msgstr ""
 # b2139995a80b403abafbd094791d301b
 msgid "To run tests from the cookbook directory:"
 msgstr ""
-

--- a/includes_openstack/includes_openstack_cookbooks_common.rst
+++ b/includes_openstack/includes_openstack_cookbooks_common.rst
@@ -1,6 +1,6 @@
 .. The contents of this file are included in multiple topics.
 .. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
 
-Installs common setup recipes, helper methods, and attributes for use with |openstack grizzly| and |openstack chef|.
+Installs common setup recipes, helper methods, and attributes for use with |openstack juno| and |openstack chef|.
 
 This cookbook is located at: https://github.com/stackforge/cookbook-openstack-common.

--- a/includes_openstack/includes_openstack_cookbooks_ops_database.rst
+++ b/includes_openstack/includes_openstack_cookbooks_ops_database.rst
@@ -2,6 +2,6 @@
 .. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
 
 
-Installs a reference database configuration for use with |openstack grizzly| and |openstack chef|. This cookbook is not required and alternate database configurations may be used. Supported databases: |mysql| (and will support |postgresql| soon).
+Installs a reference database configuration for use with |openstack juno| and |openstack chef|. This cookbook is not required and alternate database configurations may be used. Supported databases: |mysql| and |postgresql|.
 
 This cookbook is located at: https://github.com/stackforge/cookbook-openstack-ops-database.

--- a/includes_openstack/includes_openstack_cookbooks_ops_messaging.rst
+++ b/includes_openstack/includes_openstack_cookbooks_ops_messaging.rst
@@ -2,6 +2,6 @@
 .. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
 
 
-Installs a shared message queue for use with |openstack grizzly| and |openstack chef|. This cookbook is not required and alternate messaging services may be used. Supported message services: |rabbitmq|.
+Installs a shared message queue for use with |openstack juno| and |openstack chef|. This cookbook is not required and alternate messaging services may be used. Supported message services: |rabbitmq|.
 
 This cookbook is located at: https://github.com/stackforge/cookbook-openstack-ops-messaging.

--- a/swaps/swap_names.txt
+++ b/swaps/swap_names.txt
@@ -904,6 +904,7 @@
 .. |openstack compute| replace:: Compute
 .. |openstack glance| replace:: Glance
 .. |openstack grizzly| replace:: OpenStack Grizzly
+.. |openstack juno| replace:: OpenStack Juno
 .. |openstack horizon| replace:: Horizon
 .. |openstack keystone| replace:: Keystone
 .. |openstack networking| replace:: Networking
@@ -1169,13 +1170,3 @@
 .. |url ruby_doc_org| replace:: http://www.ruby-doc.org/stdlib/
 .. |url ruby_lang_org| replace:: http://www.ruby-lang.org/en/documentation/
 .. |url ruby_power_of_chef| replace:: http://blog.loftninjas.org/2011/02/16/the-power-of-chef-and-ruby/
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
All openstack occurences pointed to Grizzly instead of latest release of
Openstack (Juno). More, the ops-database cookbook now support Postgresql.
