### PR TITLE
add touch and reconfigure at secondary server, too

### DIFF
--- a/includes_install/includes_install_server_ha_drbd_establish_failover.rst
+++ b/includes_install/includes_install_server_ha_drbd_establish_failover.rst
@@ -84,3 +84,15 @@ To establish failover between the two backend machines, do the following:
       
       $ sudo chef-server-ctl reconfigure
 
+#. Run the following command on the secondary backend machine:
+
+   .. code-block:: bash
+
+      $ touch /var/opt/opscode/drbd/drbd_ready
+
+#. Reconfigure the secondary |chef server|:
+
+   .. code-block:: bash
+
+      $ sudo chef-server-ctl reconfigure
+


### PR DESCRIPTION
Unable to transition DRBD HA Chef Server

I have built DRBD HA Chef Server Cluster (1 Frontend and 2 Backends) following docs: http://docs.chef.io/install_server_ha_drbd.html

Next, I tested "Graceful Transitions" following docs: http://docs.chef.io/server_high_availability.html#graceful-transitions
Primary Backend (be1.example.jp) transitioned into Backup successfully.
But Secondary Backend (be2.example.jp) did not transition into Master.

I found be2.example.jp was incomplete "Secondary Backend".
be2.example.jp is only "DRBD Secondary", not "Chef Server Secondary".
be2.example.jp does not have keepalived.

```
[redhat@be2 ~]$ drbd-overview 
 0:pc0/0  Connected Secondary/Primary UpToDate/UpToDate 
[redhat@be2 ~]$ 

[redhat@be2 ~]$ sudo chef-server-ctl status
[redhat@be2 ~]$ 

[redhat@be2 ~]$ sudo chef-server-ctl ha-status
[ERROR] cannot check HA status if you haven't completed a reconfigure
[redhat@be2 ~]$ 

[redhat@be2 ~]$ ls -la /var/opt/opscode/
total 16
drwxr-xr-x  4 root root 4096  1月  6 16:28 2015 .
drwxr-xr-x. 3 root root 4096  1月  6 16:23 2015 ..
drwxr-xr-x  4 root root 4096  1月  6 16:28 2015 drbd
drwxr-xr-x  2 root root 4096  1月  6 16:23 2015 plugins
[redhat@be2 ~]$ 
```

Normally, "/var/opt/opscode/" directory has many Chef Server contents including keepalived.

Let's back to install docs: http://docs.chef.io/install_server_ha_drbd.html#secondary-backend
There is no procedure after CTRL-C at Secondary Backend.
I guess lacking of "touch /var/opt/opscode/drbd/drbd_ready" and re-run "chef-server-ctl reconfigure" at Secondary Backend.
At 4. and 5. of http://docs.chef.io/install_server_ha_drbd.html#establish-failover
they look like only need for Primary Backend.

So, I ran them at Secondary Backend:

```
[redhat@be2 ~]$ sudo touch /var/opt/opscode/drbd/drbd_ready
[redhat@be2 ~]$

[redhat@be2 ~]$ sudo chef-server-ctl reconfigure
    :
    (cut)
    :
[redhat@be2 ~]$
```

Secondary Backend really is.

```
[redhat@be2 ~]$ sudo chef-server-ctl status
down: bookshelf: 264s; run: log: (pid 3014) 274s
run: keepalived: (pid 3048) 272s; run: log: (pid 3063) 272s
down: nginx: 265s; run: log: (pid 3034) 273s
down: oc_bifrost: 266s; run: log: (pid 2977) 276s
down: oc_id: 267s; run: log: (pid 2989) 276s
down: opscode-erchef: 269s; run: log: (pid 3018) 274s
down: opscode-expander: 270s; run: log: (pid 3006) 275s
down: opscode-expander-reindexer: 272s; run: log: (pid 3010) 275s
down: opscode-solr4: 274s; run: log: (pid 2993) 275s
down: postgresql: 276s; run: log: (pid 2965) 277s
down: rabbitmq: 277s; run: log: (pid 2961) 277s
down: redis_lb: 279s; run: log: (pid 3030) 273s
[redhat@be2 ~]$ 

[redhat@be2 ~]$ sudo chef-server-ctl ha-status
[OK] keepalived HA services enabled.
[OK] cluster status = backup
[OK] did not find VIP IP address and I am not master
[OK] found VRRP communications interface eth0
[OK] bookshelf is not running, and I am not master.
[OK] keepalived is running.
[OK] nginx is not running, and I am not master.
[OK] oc_bifrost is not running, and I am not master.
[OK] oc_id is not running, and I am not master.
[OK] opscode-erchef is not running, and I am not master.
[OK] opscode-expander is not running, and I am not master.
[OK] opscode-expander-reindexer is not running, and I am not master.
[OK] opscode-solr4 is not running, and I am not master.
[OK] postgresql is not running, and I am not master.
[OK] rabbitmq is not running, and I am not master.
[OK] redis_lb is not running, and I am not master.

[OK] all checks passed.

[redhat@be2 ~]$ 

[redhat@be2 ~]$ ls -la /var/opt/opscode/
total 68
drwxr-xr-x  17 root          root    4096 Jan 15 13:26 .
drwxr-xr-x.  3 root          root    4096 Jan  6 16:23 ..
drwxr-x---   4 opscode       opscode 4096 Jan 15 13:25 bookshelf
drwxr-xr-x   4 root          root    4096 Jan 15 13:24 drbd
drwxr-xr-x   4 root          root    4096 Jan 15 13:26 keepalived
drwxr-x---   8 opscode       opscode 4096 Jan 15 13:26 nginx
drwxr-x---   3 opscode       opscode 4096 Jan 15 13:26 oc-chef-pedant
drwxr-x---   4 opscode       opscode 4096 Jan 15 13:25 oc_bifrost
drwxr-x---   4 opscode       opscode 4096 Jan 15 13:25 oc_id
drwxr-x---   4 opscode       opscode 4096 Jan 15 13:26 opscode-erchef
drwxr-x---   3 opscode       opscode 4096 Jan 15 13:25 opscode-expander
drwxr-x---   3 opscode       opscode 4096 Jan 15 13:25 opscode-solr4
drwxr-xr-x   2 root          root    4096 Jan  6 16:23 plugins
drwxr-x---   3 opscode-pgsql root    4096 Jan 15 13:25 postgresql
drwxr-x---   4 opscode       opscode 4096 Jan 15 13:25 rabbitmq
drwxr-x---   3 opscode       opscode 4096 Jan 15 13:26 redis_lb
drwxr-x---   3 opscode       opscode 4096 Jan 15 13:26 upgrades
[redhat@be2 ~]$ 
```

Now I retried Graceful Transitions.

```
[redhat@be1 ~]$ sudo chef-server-ctl stop keepalived
ok: down: keepalived: 0s, normally up
[redhat@be1 ~]$ 

[redhat@be1 ~]$ sudo chef-server-ctl ha-status
[OK] keepalived HA services enabled.
[OK] cluster status = backup
[OK] did not find VIP IP address and I am not master
[OK] found VRRP communications interface eth0
[OK] bookshelf is not running, and I am not master.
[ERROR] keepalived is not running.
[OK] nginx is not running, and I am not master.
[OK] oc_bifrost is not running, and I am not master.
[OK] oc_id is not running, and I am not master.
[OK] opscode-chef-mover is running.
[OK] opscode-erchef is not running, and I am not master.
[OK] opscode-expander is not running, and I am not master.
[OK] opscode-expander-reindexer is not running, and I am not master.
[OK] opscode-solr4 is not running, and I am not master.
[OK] postgresql is not running, and I am not master.
[OK] rabbitmq is not running, and I am not master.
[OK] redis_lb is not running, and I am not master.

[ERROR] ERRORS WERE DETECTED.

[redhat@be1 ~]$ 

[redhat@be1 ~]$ drbd-overview 
 0:pc0/0  Connected Secondary/Primary UpToDate/UpToDate 
[redhat@be1 ~]$ 

[redhat@be2 ~]$ sudo chef-server-ctl status
run: bookshelf: (pid 3475) 43s, normally down; run: log: (pid 3014) 484s
run: keepalived: (pid 3048) 482s; run: log: (pid 3063) 482s
run: nginx: (pid 3510) 42s, normally down; run: log: (pid 3034) 483s
run: oc_bifrost: (pid 3520) 40s, normally down; run: log: (pid 2977) 486s
run: oc_id: (pid 3552) 39s, normally down; run: log: (pid 2989) 486s
run: opscode-erchef: (pid 3562) 36s, normally down; run: log: (pid 3018) 484s
run: opscode-expander: (pid 3579) 34s, normally down; run: log: (pid 3006) 485s
run: opscode-expander-reindexer: (pid 3597) 31s, normally down; run: log: (pid 3010) 485s
run: opscode-solr4: (pid 3621) 29s, normally down; run: log: (pid 2993) 485s
run: postgresql: (pid 3644) 27s, normally down; run: log: (pid 2965) 487s
run: rabbitmq: (pid 3669) 26s, normally down; run: log: (pid 2961) 487s
run: redis_lb: (pid 3979) 12s, normally down; run: log: (pid 3030) 483s
[redhat@be2 ~]$ 

[redhat@be2 ~]$ sudo chef-server-ctl ha-status
[OK] keepalived HA services enabled.
[OK] cluster status = master
[OK] found VIP IP address and I am master
[OK] found VRRP communications interface eth0
[OK] bookshelf is running correctly, and I am master.
[OK] keepalived is running.
[OK] nginx is running correctly, and I am master.
[OK] oc_bifrost is running correctly, and I am master.
[OK] oc_id is running correctly, and I am master.
[OK] opscode-erchef is running correctly, and I am master.
[OK] opscode-expander is running correctly, and I am master.
[OK] opscode-expander-reindexer is running correctly, and I am master.
[OK] opscode-solr4 is running correctly, and I am master.
[OK] postgresql is running correctly, and I am master.
[OK] rabbitmq is running correctly, and I am master.
[OK] redis_lb is running correctly, and I am master.

[OK] all checks passed.

[redhat@be2 ~]$ 

[redhat@be2 ~]$ drbd-overview 
 0:pc0/0  Connected Primary/Secondary UpToDate/UpToDate /var/opt/opscode/drbd/data ext4 4.0G 164M 3.6G 5% 
[redhat@be2 ~]$ 
```

Everything is OK.
