### PR TITLE
update description for 401 unauthorized and removed unused/invalid 401 conflict

### DIFF
--- a/swaps/swap_descriptions.txt
+++ b/swaps/swap_descriptions.txt
@@ -507,7 +507,7 @@
 .. H
 ..
 
-.. |ha backend| replace:: Backend servers in high availability topologies should have this setting enabled. 
+.. |ha backend| replace:: Backend servers in high availability topologies should have this setting enabled.
 .. |ha true| replace:: When ``topology`` is set to ``ha``, this setting will default to ``true``.
 .. |handler method_all_resources| replace:: A list of all resources that are included in the ``resource_collection`` property for the current |chef client| run.
 .. |handler method_backtrace| replace:: A backtrace associated with the uncaught exception data which caused a |chef client| run to fail, if present; ``nil`` for a successful |chef client| run.
@@ -1215,8 +1215,7 @@
 .. |response code 400 bad request sandbox| replace:: Bad request. The object has already been committed or one (or more) of the objects were not properly uploaded.
 .. |response code 400 checksum| replace:: The contents of the file do not have the correct checksum.
 .. |response code 400 unsuccessful| replace:: The request was unsuccessful.
-.. |response code 401 conflict| replace:: Conflict. The object already exists.
-.. |response code 401 unauthorized| replace:: Unauthorized. The user which made the request is not authorized to perform the action.
+.. |response code 401 unauthorized| replace:: Unauthorized. The user or client who made the request could not be authenticated. Verify the user/client name, and that the correct key was used to sign the request.
 .. |response code 403 forbidden| replace:: Forbidden. The user which made the request is not authorized to perform the action.
 .. |response code 403 unauthorized| replace:: Unauthorized. The user which made the request is not authorized to perform the action.
 .. |response code 404 not found| replace:: Not found. The requested object does not exist.


### PR DESCRIPTION
I  hope I did this right, this was my first foray into docs update in quite a while. 

Updated 401 description to be more accurate, and provide possible corrective measures. 

Removed '401 conflict' message, as it was unreferenced and not a valid combination (401 is always unauthorized). 
