### PR TITLE
remove support for Solaris 9 (official support ended October 2014)

### DIFF
--- a/chef_master/source/chef_system_requirements.rst
+++ b/chef_master/source/chef_system_requirements.rst
@@ -34,9 +34,6 @@ The |chef client| can run on the following systems:
      - 12.1
      - i686, x86_64
    * - Solaris
-     - 5.9
-     - sparc
-   * - 
      - 5.10. 5.11
      - i386, sparc
    * - SUSE Enterprise
@@ -48,7 +45,7 @@ The |chef client| can run on the following systems:
    * - Windows
      - 2003 R2, 2008
      - i686, x86_64
-   * - 
+   * -
      - 2008 R2, 2012
      - x86_64
 
@@ -146,6 +143,3 @@ The open source |chef server| can run on the following systems:
    * - Ubuntu
      - 10.04, 10.10, 11.04, 11.10, 12.04, 12.10
      - i686, x86_64
-
-
-

--- a/includes_api_omnitruck/includes_api_omnitruck_client_supported_versions.rst
+++ b/includes_api_omnitruck/includes_api_omnitruck_client_supported_versions.rst
@@ -1,12 +1,12 @@
 .. The contents of this file are included in multiple topics.
-.. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets. 
+.. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
 
 The following table lists the versions that are available for the |chef client|:
 
 .. list-table::
    :widths: 320 60 60 60
    :header-rows: 1
- 
+
    * - Platform
      - p
      - pv
@@ -15,15 +15,15 @@ The following table lists the versions that are available for the |chef client|:
      - ``el``
      - ``5``
      - ``x86_64``
-   * - 
+   * -
      - ``el``
      - ``5``
      - ``i686``
-   * - 
+   * -
      - ``el``
      - ``6``
      - ``x86_64``
-   * - 
+   * -
      - ``el``
      - ``6``
      - ``i686``
@@ -31,7 +31,7 @@ The following table lists the versions that are available for the |chef client|:
      - ``debian``
      - ``6``
      - ``x86_64``
-   * - 
+   * -
      - ``debian``
      - ``6``
      - ``i686``
@@ -39,7 +39,7 @@ The following table lists the versions that are available for the |chef client|:
      - ``freebsd``
      - ``9``
      - ``amd64``
-   * - 
+   * -
      - ``freebsd``
      - ``9``
      - ``i386``
@@ -47,7 +47,7 @@ The following table lists the versions that are available for the |chef client|:
      - ``mac_os_x``
      - ``10.6``
      - ``x86_64``
-   * - 
+   * -
      - ``mac_os_x``
      - ``10.7``
      - ``x86_64``
@@ -55,19 +55,15 @@ The following table lists the versions that are available for the |chef client|:
      - ``solaris2``
      - ``5.10``
      - ``i386``
-   * - 
+   * -
      - ``solaris2``
      - ``5.11``
      - ``i386``
-   * - 
-     - ``solaris2``
-     - ``5.9``
-     - ``sparc``
-   * - 
+   * -
      - ``solaris2``
      - ``5.10``
      - ``sparc``
-   * - 
+   * -
      - ``solaris2``
      - ``5.11``
      - ``sparc``
@@ -75,7 +71,7 @@ The following table lists the versions that are available for the |chef client|:
      - ``suse``
      - ``12.1``
      - ``x86_64``
-   * - 
+   * -
      - ``suse``
      - ``12.1``
      - ``i686``
@@ -83,7 +79,7 @@ The following table lists the versions that are available for the |chef client|:
      - ``sles``
      - ``11.2``
      - ``i686``
-   * - 
+   * -
      - ``sles``
      - ``11.2``
      - ``x86_64``
@@ -91,55 +87,55 @@ The following table lists the versions that are available for the |chef client|:
      - ``ubuntu``
      - ``10.04``
      - ``x86_64``
-   * - 
+   * -
      - ``ubuntu``
      - ``10.10``
      - ``x86_64``
-   * - 
+   * -
      - ``ubuntu``
      - ``10.04``
      - ``i686``
-   * - 
+   * -
      - ``ubuntu``
      - ``10.10``
      - ``i686``
-   * - 
+   * -
      - ``ubuntu``
      - ``11.04``
      - ``x86_64``
-   * - 
+   * -
      - ``ubuntu``
      - ``11.10``
      - ``x86_64``
-   * - 
+   * -
      - ``ubuntu``
      - ``12.04``
      - ``x86_64``
-   * - 
+   * -
      - ``ubuntu``
      - ``12.10``
      - ``x86_64``
-   * - 
+   * -
      - ``ubuntu``
      - ``13.04``
      - ``x86_64``
-   * - 
+   * -
      - ``ubuntu``
      - ``11.04``
      - ``i686``
-   * - 
+   * -
      - ``ubuntu``
      - ``11.10``
      - ``i686``
-   * - 
+   * -
      - ``ubuntu``
      - ``12.04``
      - ``i686``
-   * - 
+   * -
      - ``ubuntu``
      - ``12.10``
      - ``i686``
-   * - 
+   * -
      - ``ubuntu``
      - ``13.04``
      - ``i686``
@@ -147,24 +143,23 @@ The following table lists the versions that are available for the |chef client|:
      - ``windows``
      - ``2008r2``
      - ``x86_64``
-   * - 
+   * -
      - ``windows``
      - ``2003r2``
      - ``i686``
-   * - 
+   * -
      - ``windows``
      - ``2003r2``
      - ``x86_64``
-   * - 
+   * -
      - ``windows``
      - ``2008``
      - ``x86_64``
-   * - 
+   * -
      - ``windows``
      - ``2008``
      - ``i686``
-   * - 
+   * -
      - ``windows``
      - ``2012``
      - ``x86_64``
-

--- a/includes_chef/includes_system_requirements_chef_omnibus.rst
+++ b/includes_chef/includes_system_requirements_chef_omnibus.rst
@@ -1,5 +1,5 @@
 .. The contents of this file are included in multiple topics.
-.. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets. 
+.. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
 
 The |omnibus installer| can be used to install |chef| on the following operating systems and versions:
 
@@ -7,10 +7,7 @@ The |omnibus installer| can be used to install |chef| on the following operating
 * |redhat enterprise linux| 5.x, 6.x
 * |mac os x| 10.6, 10.7
 * |suse els| 11.2
-* |solaris| 5.9 (sparc only), 5.10 (sparc and i386), 5.11 (sparc and i386)
+* |solaris| 5.10 (sparc and i386), 5.11 (sparc and i386)
 * |opensuse| 12.1
 * |ubuntu| 10.04, 10.10, 11.04, 11.10, 12.04
 * |windows server| 2003, 2008, 2008 R2
-
-
-


### PR DESCRIPTION
Remove Solaris 9 from the support matrix since Oracle discontinued it in October per our official policy: 
https://github.com/chef/chef-rfc/blob/master/rfc021-platform-support-policy.md#appendix-guiding-principles-for-operating-system-version-support

My editor strips trailing whitespace, if this is an issue I can submit a cleaner patch.
