### PR TITLE
directories should be executable

### DIFF
--- a/includes_resources/includes_resource_directory_syntax.rst
+++ b/includes_resources/includes_resource_directory_syntax.rst
@@ -25,7 +25,7 @@ For example:
    directory "/var/lib/foo" do
      owner 'root'
      group 'root'
-     mode '0644'
+     mode '0755'
      action :create
    end
 


### PR DESCRIPTION
example directory in docs was being created with mode 644, should be 755.  I hope chef doesn't automatically add the execute bit if mode is specified, could be very bad.
