### PR TITLE
Fix the multiline cron example using %Q{ }

### DIFF
--- a/includes_resources/includes_resource_cron_syntax.rst
+++ b/includes_resources/includes_resource_cron_syntax.rst
@@ -30,10 +30,10 @@ For example, weekly cookbook reports:
      user "getchef"
      mailto "nharvey@chef.io"
      home "/srv/supermarket/shared/system"
-     command %Q{
-       cd /srv/supermarket/current &&
-       env RUBYLIB="/srv/supermarket/current/lib"
-       RAILS_ASSET_ID=`git rev-parse HEAD` RAILS_ENV="#{rails_env}"
-       bundle exec rake cookbooks_report
+     command %Q{ \
+       cd /srv/supermarket/current && \
+       env RUBYLIB="/srv/supermarket/current/lib" \
+       RAILS_ASSET_ID=`git rev-parse HEAD` RAILS_ENV="#{rails_env}" \
+       bundle exec rake cookbooks_report \
      }
    end


### PR DESCRIPTION
The current multiline example using `%Q{..}` fails to execute and throws an
exception. The example needs to have line continuation on it.

I've made a gist showing the failure and the working examples:

https://gist.github.com/gsandie/dc70a2460509124c39c1

The gist shows it working with 12.0.3 but I also tested with 11.6.
