### PR TITLE
Solaris 9 is no longer supported.

### DIFF
--- a/includes_supported_platforms/includes_supported_platforms_client_tier1.rst
+++ b/includes_supported_platforms/includes_supported_platforms_client_tier1.rst
@@ -30,7 +30,7 @@ The following table lists the Tier 1 supported platforms for the |chef client|:
      - ``5``, ``6``, ``7``
    * - |solaris|
      - ``sparc``, ``x86``
-     - ``9``, ``10``, ``11``
+     - ``10``, ``11``
    * - |ubuntu|
      - ``x86``, ``x86_64``
      - ``10.04``, ``12.04``, ``14.04``


### PR DESCRIPTION
Solaris 9 is now EOL per the platform support policy.
