### PR TITLE
Add example for searching by cookbook recipes

### DIFF
--- a/step_knife/step_knife_search_by_recipe.rst
+++ b/step_knife/step_knife_search_by_recipe.rst
@@ -6,6 +6,12 @@ To search for recipes that are used by a node, use the ``recipes`` attribute to 
 
    $ knife search node 'recipes:recipe_name'
    
+or (note the escaping of the double colon):
+
+.. code-block:: bash
+
+   $ knife search node 'recipes:cookbook_name\:\:recipe_name'
+
 or:
 
 .. code-block:: bash


### PR DESCRIPTION
I'd tried several combinations (double colon, single colon, dot, underscore) before finding out how to do this in a 'tips and tricks' article. I think it's worth mentioning in the official docs, as it's in no way obvious.

I hope I've edited the right file here – the intention is to update the 'Search by recipe' section on https://docs.chef.io/knife_search.html

Thanks
