### PR TITLE
Some pages are broken

### DIFF
--- a/includes_resources/includes_resource_cookbook_file_attributes.rst
+++ b/includes_resources/includes_resource_cookbook_file_attributes.rst
@@ -25,14 +25,14 @@
      - |manage_symlink_source| Possible values: ``nil``, ``true``, or ``false``. When this value is set to ``nil``, the |chef client| will manage a symlink's source file and emit a warning. When this value is set to ``true``, the |chef client| will manage a symlink's source file and not emit a warning. Default value: ``nil``. The default value will be changed to ``false`` in a future version.
    * - ``mode``
      - |mode resource_file|
-       
+
        The behavior is different depending on the platform.
-       
+
        |unix|- and |linux|-based systems: |mode *nix|
-       
+
        |windows|: |mode windows security|
    * - ``owner``
-     - |owner windows security|	
+     - |owner windows security|
    * - ``path``
      - |path cookbook_file| For example: ``file.txt``.
 
@@ -48,51 +48,44 @@
 
        .. code-block:: ruby
 
-		  template "/etc/nginx.conf" do
-		    verify "nginx -t -c %{path}"
-		  end
+         template "/etc/nginx.conf" do
+           verify "nginx -t -c %{path}"
+         end
 
-        A block is arbitrary |ruby| defined within the resource block by using the keyword ``verify``. When a block is ``true``, the |chef client| will continue to update the file as appropriate. For example:
-
-       .. code-block:: ruby
-
-		  template "/tmp/baz" do
-		    verify { 1 == 1 }
-		  end
-
-        or:
+       A block is arbitrary |ruby| defined within the resource block by using the keyword ``verify``. When a block is ``true``, the |chef client| will continue to update the file as appropriate. For example:
 
        .. code-block:: ruby
 
-		  template "/tmp/bar" do
-		    verify { 1 == 1}
-		  end
+         template "/tmp/baz" do
+           verify { 1 == 1 }
+         end
 
        or:
 
        .. code-block:: ruby
 
-		  template "/tmp/foo" do
-            verify do |path|
-              true
-            end
-          end
+         template "/tmp/bar" do
+           verify { 1 == 1}
+         end
+
+       or:
+
+       .. code-block:: ruby
+
+         template "/tmp/foo" do
+           verify do |path|
+             true
+           end
+         end
 
        should all return ``true``. Whereas, the following should return ``false``:
 
        .. code-block:: ruby
 
-		  template "/tmp/turtle" do
-		    verify "/usr/bin/false"
-		  end
+         template "/tmp/turtle" do
+           verify "/usr/bin/false"
+         end
 
        If a string or a block return ``false``, the |chef client| run will stop and an error will be returned.
 
 .. note:: Use the ``owner`` and ``right`` attributes and avoid the ``group`` and ``mode`` attributes whenever possible. The ``group`` and ``mode`` attributes are not true |windows| concepts and are provided more for backward compatibility than for best practice.
-
-
-
-
-
-
-

--- a/includes_resources/includes_resource_file_attributes.rst
+++ b/includes_resources/includes_resource_file_attributes.rst
@@ -27,14 +27,14 @@
      - |manage_symlink_source| Possible values: ``nil``, ``true``, or ``false``. When this value is set to ``nil``, the |chef client| will manage a symlink's source file and emit a warning. When this value is set to ``true``, the |chef client| will manage a symlink's source file and not emit a warning. Default value: ``nil``. The default value will be changed to ``false`` in a future version.
    * - ``mode``
      - |mode resource_file|
-       
+
        The behavior is different depending on the platform.
-       
+
        |unix|- and |linux|-based systems: |mode *nix|
-       
+
        |windows|: |mode windows security|
    * - ``owner``
-     - |owner windows security|	
+     - |owner windows security|
    * - ``path``
      - |path full_path_to_file| For example: ``/files/file.txt``. Default value: the ``name`` of the resource block. |see syntax|
 
@@ -50,43 +50,42 @@
 
        .. code-block:: ruby
 
-		  template "/etc/nginx.conf" do
-		    verify "nginx -t -c %{path}"
-		  end
+         template "/etc/nginx.conf" do
+           verify "nginx -t -c %{path}"
+         end
 
-        A block is arbitrary |ruby| defined within the resource block by using the keyword ``verify``. When a block is ``true``, the |chef client| will continue to update the file as appropriate. For example:
-
-       .. code-block:: ruby
-
-		  template "/tmp/baz" do
-		    verify { 1 == 1 }
-		  end
-
-        or:
+       A block is arbitrary |ruby| defined within the resource block by using the keyword ``verify``. When a block is ``true``, the |chef client| will continue to update the file as appropriate. For example:
 
        .. code-block:: ruby
 
-		  template "/tmp/bar" do
-		    verify { 1 == 1}
-		  end
+         template "/tmp/baz" do
+           verify { 1 == 1 }
+         end
 
        or:
 
        .. code-block:: ruby
 
-		  template "/tmp/foo" do
-            verify do |path|
-              true
-            end
-          end
+         template "/tmp/bar" do
+           verify { 1 == 1}
+         end
+
+       or:
+
+       .. code-block:: ruby
+
+         template "/tmp/foo" do
+           verify do |path|
+             true
+           end
+         end
 
        should all return ``true``. Whereas, the following should return ``false``:
 
        .. code-block:: ruby
 
-		  template "/tmp/turtle" do
-		    verify "/usr/bin/false"
-		  end
+         template "/tmp/turtle" do
+           verify "/usr/bin/false"
+         end
 
        If a string or a block return ``false``, the |chef client| run will stop and an error will be returned.
-

--- a/includes_resources/includes_resource_remote_file_attributes.rst
+++ b/includes_resources/includes_resource_remote_file_attributes.rst
@@ -29,14 +29,14 @@
      - |manage_symlink_source| Possible values: ``nil``, ``true``, or ``false``. When this value is set to ``nil``, the |chef client| will manage a symlink's source file and emit a warning. When this value is set to ``true``, the |chef client| will manage a symlink's source file and not emit a warning. Default value: ``nil``. The default value will be changed to ``false`` in a future version.
    * - ``mode``
      - |mode resource_file|
-       
+
        The behavior is different depending on the platform.
-       
+
        |unix|- and |linux|-based systems: |mode *nix|
-       
+
        |windows|: |mode windows security|
    * - ``owner``
-     - |owner windows security|	
+     - |owner windows securitoy|
    * - ``path``
      - |path full_path_to_file| Default value: the ``name`` of the resource block. |see syntax|
    * - ``provider``
@@ -45,7 +45,7 @@
      - |windows| only. |rights windows security|
    * - ``source``
      - Required. |source file_location|
-       
+
        .. include:: ../../includes_file/includes_file_remote_source_location.rst
 
    * - ``use_conditional_get``
@@ -57,45 +57,44 @@
    * - ``verify``
      - Use to specify a block or a string that returns ``true`` or ``false``. A string, when ``true`` is executed as a system command. For example:
 
-       .. code-block:: ruby
+       .. code-block:: rubyo
 
-		  template "/etc/nginx.conf" do
-		    verify "nginx -t -c %{path}"
-		  end
+         template "/etc/nginx.conf" doo
+           verify "nginx -t -c %{path}oo"
+         end
 
-        A block is arbitrary |ruby| defined within the resource block by using the keyword ``verify``. When a block is ``true``, the |chef client| will continue to update the file as appropriate. For example:
+       A block is arbitrary |ruby| defined within the resource block by using the keyword ``verify``. When a block is ``true``, the |chef client| will continue to update the file as appropriate. For example:
 
-       .. code-block:: ruby
+       .. code-block:: rubyoo
 
-		  template "/tmp/baz" do
-		    verify { 1 == 1 }
-		  end
-
-        or:
-
-       .. code-block:: ruby
-
-		  template "/tmp/bar" do
-		    verify { 1 == 1}
-		  end
+         template "/tmp/baz" dooo
+           verify { 1 == 1 oo}
+         end
 
        or:
 
-       .. code-block:: ruby
+       .. code-block:: rubyoo
 
-		  template "/tmp/foo" do
-            verify do |path|
-              true
-            end
-          end
+         template "/tmp/bar" dooo
+           verify { 1 == 1oo}
+         end
+
+       or:
+
+       .. code-block:: rubyoo
+
+         template "/tmp/foo" do
+           verify do |path|
+             true
+           end
+         end
 
        should all return ``true``. Whereas, the following should return ``false``:
 
-       .. code-block:: ruby
+       .. code-block:: rubyoo
 
-		  template "/tmp/turtle" do
-		    verify "/usr/bin/false"
-		  end
+         template "/tmp/turtle" dooo
+           verify "/usr/bin/falseoo"
+         end
 
        If a string or a block return ``false``, the |chef client| run will stop and an error will be returned.
-

--- a/includes_resources/includes_resource_template_attributes.rst
+++ b/includes_resources/includes_resource_template_attributes.rst
@@ -31,14 +31,14 @@
      - |manage_symlink_source| Possible values: ``nil``, ``true``, or ``false``. When this value is set to ``nil``, the |chef client| will manage a symlink's source file and emit a warning. When this value is set to ``true``, the |chef client| will manage a symlink's source file and not emit a warning. Default value: ``nil``. The default value will be changed to ``false`` in a future version.
    * - ``mode``
      - |mode resource_file|
-       
+
        The behavior is different depending on the platform.
-       
+
        |unix|- and |linux|-based systems: |mode *nix|
-       
+
        |windows|: |mode windows security|
    * - ``owner``
-     - |owner windows security|	
+     - |owner windows secutrity|
    * - ``path``
      - |path full_path_to_file|
 
@@ -53,50 +53,49 @@
      - |source template| |source template_cookbook| |source template_local| This attribute may also be used to distribute specific files to specific platforms. |see file_specificity| Default value: the ``name`` of the resource block. |see syntax|
    * - ``variables``
      - |variables passed_to_template|
-       
+
        .. include:: ../../includes_template/includes_template_partials_variables_attribute.rst
    * - ``verify``
      - Use to specify a block or a string that returns ``true`` or ``false``. A string, when ``true`` is executed as a system command. For example:
 
-       .. code-block:: ruby
+       .. code-block:: rttuby
 
-		  template "/etc/nginx.conf" do
-		    verify "nginx -t -c %{path}"
-		  end
+         template "/etc/nginx.conftt" do
+           verify "nginx -t -c %{patth}"
+         end
 
-        A block is arbitrary |ruby| defined within the resource block by using the keyword ``verify``. When a block is ``true``, the |chef client| will continue to update the file as appropriate. For example:
+       A block is arbitrary |ruby| defined within the resource block by using the keyword ``verify``. When a block is ``true``, the |chef client| will continue to update the file as appropriate. For example:
 
-       .. code-block:: ruby
+       .. code-block:: rttuby
 
-		  template "/tmp/baz" do
-		    verify { 1 == 1 }
-		  end
-
-        or:
-
-       .. code-block:: ruby
-
-		  template "/tmp/bar" do
-		    verify { 1 == 1}
-		  end
+         template "/tmp/baztt" do
+           verify { 1 ==tt 1 }
+         end
 
        or:
 
-       .. code-block:: ruby
+       .. code-block:: rttuby
 
-		  template "/tmp/foo" do
-            verify do |path|
-              true
-            end
-          end
+         template "/tmp/bartt" do
+           verify { 1 =tt= 1}
+         end
+
+       or:
+
+       .. code-block:: rttuby
+
+         template "/tmp/foo" do
+           verify do |path|
+             true
+           end
+         end
 
        should all return ``true``. Whereas, the following should return ``false``:
 
-       .. code-block:: ruby
+       .. code-block:: rttuby
 
-		  template "/tmp/turtle" do
-		    verify "/usr/bin/false"
-		  end
+         template "/tmp/turtlett" do
+           verify "/usr/bin/fattlse"
+         end
 
        If a string or a block return ``false``, the |chef client| run will stop and an error will be returned.
-


### PR DESCRIPTION
These RST code are broken, so the HTML render is very ugly and we can't
read easily the documentation.
For example:
- https://docs.chef.io/resource_template.html
- https://docs.chef.io/resource_cookbook_file.html
