### PR TITLE
Create is not a valid action for machine resource

### DIFF
--- a/step_resource/step_resource_machine_file_get_remote_file.rst
+++ b/step_resource/step_resource_machine_file_get_remote_file.rst
@@ -1,4 +1,4 @@
-.. This is an included how-to. 
+.. This is an included how-to.
 
 
 A deployment process requires more than just setting up machines. For example, files may need to be copied to machines from remote locations. The following example shows how to use the |resource remote_file| resource to grab a tarball from a URL, create a machine, copy that tarball to the machine, and then get that machine running by using a recipe that installs and configures that tarball on the machine:
@@ -10,7 +10,7 @@ A deployment process requires more than just setting up machines. For example, f
    end
 
    machine 'x'
-     action :create
+     action :allocate
    end
 
    machine_file '/tmp/mytarball.tgz' do
@@ -21,4 +21,5 @@ A deployment process requires more than just setting up machines. For example, f
 
    machine 'x' do
      recipe 'untarthatthing'
+     action :converge
    end


### PR DESCRIPTION
Reasons:
- action :create does not exist with machine resource

Changes:
- Change :create to :allocate
- Adding action :converge to show exactly what we can do
