### PR TITLE
Zendesk 3742 - Manage config overspecified

### DIFF
--- a/includes_ctl_chef_server/includes_ctl_chef_server_install_features_download_ha.rst
+++ b/includes_ctl_chef_server/includes_ctl_chef_server_install_features_download_ha.rst
@@ -32,8 +32,6 @@ The ``install`` subcommand downloads packages from https://packagecloud.io/ by d
 
           $ chef-server-ctl reconfigure 
 
-       .. include:: ../../includes_install/includes_install_manage_copy_secrets.rst
-
    * - |push jobs_title|
      - Use |push jobs| to run jobs---an action or a command to be executed---against nodes independently of a |chef client| run.
 

--- a/includes_install/includes_install_manage_copy_secrets.rst
+++ b/includes_install/includes_install_manage_copy_secrets.rst
@@ -1,4 +1,0 @@
-.. The contents of this file are included in multiple topics.
-.. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
-
-This updates the |chef server| and creates the ``/etc/opscode-manage/secrets.rb`` file. Copy the ``secrets.rb`` file in the ``/etc/opscode-manage`` directory on one of the frontend machines to the same directory on each of the other frontend machines.


### PR DESCRIPTION
The secrets will actually come out of `/etc/opscode`, copied from the bootstrap backend initially.
