### PR TITLE
Update ldap settings to clarify anonymous binding and group_dn

### DIFF
--- a/includes_config/includes_config_rb_server_settings_ldap.rst
+++ b/includes_config/includes_config_rb_server_settings_ldap.rst
@@ -12,13 +12,33 @@ This configuration file has the following settings for ``ldap``:
    * - ``ldap['base_dn']``
      - |ldap base_dn| For |windows ad|, this is typically ``cn=users`` and then the domain. For example: ``'OU=Employees,OU=Domain users,DC=example,DC=com'``. Default value: ``nil``.
    * - ``ldap['bind_dn']``
-     - |ldap bind_dn| This is often the administrator or manager user. This user needs to have read access to all |ldap| users that require authentication. |chef server oec| must do an |ldap| search before any user can log in. Many |windows ad| and |ldap| systems do not allow an anonymous bind. If anonymous bind is allowed, leave the ``bind_dn`` setting blank. If anonymous bind is not allowed, a user with ``READ`` access to the directory is required. This user must be specified as an |ldap| distinguished name similar to ``'CN=user_who_can_search,OU=Employees,OU=Domain users,DC=example,DC=com'``. Default value: ``nil``.
+     - |ldap bind_dn| The users that the |chef server| will use when
+       performing LDAP searches. This is often the administrator or
+       manager user. This user needs to have read access to all |ldap|
+       users that require authentication. |chef server oec| must do an
+       |ldap| search before any user can log in. Many |windows ad| and
+       |ldap| systems do not allow an anonymous bind. If anonymous
+       bind is allowed, leave the ``bind_dn`` and ``bind_password`` settings blank. If
+       anonymous bind is not allowed, a user with ``READ`` access to
+       the directory is required. This user must be specified as an
+       |ldap| distinguished name similar to
+       ``'CN=user_who_can_search,OU=Employees,OU=Domain
+       users,DC=example,DC=com'``. Default value: ``nil``.
    * - ``ldap['bind_password']``
-     - |ldap bind_password| Leave this value unset if anonymous bind is sufficient. Default value: ``nil``.
+     - |ldap bind_password| The password for the user specified by
+       ``ldap['bind_dn']``. Leave this value and ``ldap['bind_dn']``
+       unset if anonymous bind is sufficient. Default value: ``nil``.
+   * - ``ldap['group_dn']``
+     - |ldap group_dn| When set to the distinguished name of a group,
+       only members of that group can log in. This feature filters
+       based on the memberOf attribute and only works with LDAP
+       servers that provide such an attribute.  In OpenLDAP, the
+       memberOf overlay provides this attribute.
    * - ``ldap['host']``
-     - |ldap host| Be sure the |chef server oec| is able to resolve any host names. Default value: ``ldap-server-host``.
+     - |ldap host| The hostname of the LDAP/AD server. Be sure the |chef server oec| is able to resolve any host names. Default value: ``ldap-server-host``.
    * - ``ldap['login_attribute']``
-     - Use to specify the |chef server| user name for an |ldap| user. Default value: ``sAMAccountName``.
+     - The attribute used when searching for LDAP users given the
+       provided ``base_dn``. Use to specify the |chef server| user name for an |ldap| user. Default value: ``sAMAccountName``.
    * - ``ldap['port']``
      - |ldap port| The default value is an appropriate value for most configurations. Default value: ``389`` or ``636`` when ``ldap['encryption']`` is set to ``:simple_tls``.
    * - ``ldap['ssl_enabled']``


### PR DESCRIPTION
- Anonymous binding requires both bind_dn and bind_password to be
  unset. Make this more clear by specifying it in the descriptions of
  both options.
- Add an entry for the `group_dn` option.
