### PR TITLE
Use local_path instead of path

### DIFF
--- a/step_resource/step_resource_machine_file_get_remote_file.rst
+++ b/step_resource/step_resource_machine_file_get_remote_file.rst
@@ -15,7 +15,7 @@ A deployment process requires more than just setting up machines. For example, f
 
    machine_file '/tmp/mytarball.tgz' do
      machine 'x'
-     path 'mytarball.tgz'
+     local_path 'mytarball.tgz'
      action :upload
    end
 


### PR DESCRIPTION
path is equal to the name of the resource and not used for the local path for machine_file lwrp.
