### PR TITLE
Fix a typo in knife search documentation

### DIFF
--- a/swaps/swap_descriptions.txt
+++ b/swaps/swap_descriptions.txt
@@ -1314,7 +1314,7 @@
 .. |search index_environment| replace:: An environment is a way to map an organization's real-life workflow to what can be configured and managed when using |chef server|.
 .. |search index_node| replace:: A node is any server or virtual server that is configured to be maintained by a |chef client|.
 .. |search index_role| replace:: A role is a way to define certain patterns and processes that exist across nodes in an organization as belonging to a single job function.
-.. |search key| replace:: A field name/description pair is available in the |json| object. Use the field name when searching for this informatoin in the |json| object.
+.. |search key| replace:: A field name/description pair is available in the |json| object. Use the field name when searching for this information in the |json| object.
 .. |search pattern| replace:: A search pattern is a way to fine-tune search results by returning anything that matches some type of incomplete search query.
 .. |search operator| replace:: An operator can be used to ensure that certain terms are included in the results, are excluded from the results, or are not included even when other aspects of the query match.
 .. |search partial| replace:: A partial search query allows a search query to be made against specific attribute keys that are stored on the |chef server|.


### PR DESCRIPTION
As seen on https://docs.chef.io/knife_search.html.

I'm not sure how these swaps work, but this is the only occurrence I could find in the repo – so apologies if this is not the right file to be editing!
