### PR TITLE
Reflect new behavior of data_bag_item() introduced by chef/chef#1853 (handle encryption)

### DIFF
--- a/chef_master/source/data_bags.rst
+++ b/chef_master/source/data_bags.rst
@@ -99,10 +99,6 @@ Create and edit
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 .. include:: ../../includes_data_bag/includes_data_bag_recipes_edit_within_recipe.rst
 
-Access from recipe
-+++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. include:: ../../includes_data_bag/includes_data_bag_recipes_access_encrypted_data.rst
-
 Create users
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 .. include:: ../../includes_data_bag/includes_data_bag_recipes_create_users.rst

--- a/includes_data_bag/includes_data_bag_recipes_load_using_recipe_dsl.rst
+++ b/includes_data_bag/includes_data_bag_recipes_load_using_recipe_dsl.rst
@@ -1,10 +1,10 @@
 .. The contents of this file are included in multiple topics.
 .. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
 
-The |dsl recipe| provides access to data bags and data bag items with the following methods:
+The |dsl recipe| provides access to data bags and data bag items (including encrypted data bag items) with the following methods:
 
 * ``data_bag(bag)``, where ``bag`` is the name of the data bag.
-* ``data_bag_item('bag', 'item')``, where ``bag`` is the name of the data bag and ``item`` is the name of the data bag item.
+* ``data_bag_item('bag', 'item', 'secret_file')``, where ``bag`` is the name of the data bag and ``item`` is the name of the data bag item. ``secret_file`` is an optional parameter which specifies the path to an alternate encrypted data bag secret file.
 
 The ``data_bag`` method returns an array with a key for each of the data bag items that are found in the data bag. For example, a data bag named "admins" with a single data bag item named "justin" could be loaded with:
 
@@ -29,3 +29,5 @@ to return something like this:
 .. code-block:: ruby
 
    # => {"comment"=>"Justin Currie", "gid"=>1005, "id"=>"justin", "uid"=>1005, "shell"=>"/bin/zsh"}
+
+If ``item`` is encrypted, ``data_bag_item`` will automatically decrypt it using the key specified above, or (if none is specified) by the ``Chef::Config[:encrypted_data_bag_secret]`` method, which defaults to ``/etc/chef/encrypted_data_bag_secret``.


### PR DESCRIPTION
The docs, as they currently stand, while accurate, do not reflect the improved nature of accessing an encrypted data bag item.

As of Chef 12.0.0, the `data_bag_item` method autodetects encrypted data bags, obviating the need for the `EncryptedDataBagItem.load` method in most circumstances. 

This PR (chef/chef#1853) updates the docs to reflect that, and consolidates them to be more succinct.
