### PR TITLE
.chefignore => chefignore

### DIFF
--- a/swaps/swap_names.txt
+++ b/swaps/swap_names.txt
@@ -609,7 +609,7 @@
 
 .. |analytics rb| replace:: opscode-analytics.rb
 .. |berksfile| replace:: Berksfile
-.. |chefignore| replace:: .chefignore
+.. |chefignore| replace:: chefignore
 .. |chef server rb| replace:: chef-server.rb
 .. |chef_shell rb| replace:: chef-shell.rb
 .. |chef_sync rb| replace:: chef-sync.rb


### PR DESCRIPTION
Looks like `.chefignore` was renamed to `chefignore` (no dot prefix) a couple of years ago but the docs were never updated?

https://www.chef.io/blog/2011/04/29/chef-0-10-preview-chefignore/
https://github.com/chef/chef/blob/master/lib/chef/cookbook/chefignore.rb#L64
https://github.com/chef/chef/blob/master/spec/integration/knife/chefignore_spec.rb#L37
