### PR TITLE
Fixing subcommand names

### DIFF
--- a/chef_master/source/ctl_chef_server.rst
+++ b/chef_master/source/ctl_chef_server.rst
@@ -105,7 +105,7 @@ delete-user-key
 
 .. include:: ../../includes_ctl_chef_server/includes_ctl_chef_server_delete_user_key_options.rst
 
-list-client-key
+list-client-keys
 -----------------------------------------------------
 .. include:: ../../includes_ctl_chef_server/includes_ctl_chef_server_list_client_keys.rst
 
@@ -119,7 +119,7 @@ list-client-key
 
 .. include:: ../../includes_ctl_chef_server/includes_ctl_chef_server_list_client_keys_options.rst
 
-list-user-key
+list-user-keys
 -----------------------------------------------------
 .. include:: ../../includes_ctl_chef_server/includes_ctl_chef_server_list_user_keys.rst
 

--- a/includes_ctl_chef_server/includes_ctl_chef_server_list_client_keys_syntax.rst
+++ b/includes_ctl_chef_server/includes_ctl_chef_server_list_client_keys_syntax.rst
@@ -7,6 +7,6 @@ This subcommand has the following syntax:
 
 .. code-block:: bash
 
-   $ chef-server-ctl list-user-keys ORG_NAME CLIENT_NAME [--hide-public-keys]
+   $ chef-server-ctl list-client-keys ORG_NAME CLIENT_NAME [--hide-public-keys]
 
 .. warning:: The parameters for this subcommand must be in the order specified above.


### PR DESCRIPTION
Minor typo / pre-release command name fixes.  The "this is pre-release documentation for 12.03" warning could probably also be dropped.
