### PR TITLE
Dropping notes about needing to create postgres and chef users

### DIFF
--- a/chef_master/source/install_server.rst
+++ b/chef_master/source/install_server.rst
@@ -19,9 +19,6 @@ The |chef server| has the :doc:`following prerequisites </install_server_pre>`:
 * A local mail transfer agent that allows the |chef server| to send email notifications
 * Using |cron| and the ``/etc/cron.d`` directory for periodic maintenance tasks
 * Disabling the |apache qpid| daemon on |centos| and |redhat| systems
-* A local user account under which services will run
-* A local user account for |postgresql|
-* A group account under which services will run
 
 Standalone
 =====================================================


### PR DESCRIPTION
On modern chef servers, these pre-requisites no longer seem to apply.
