### PR TITLE
User AND Groups Must Be Precreated

### DIFF
--- a/includes_install/includes_install_common_uid_max.rst
+++ b/includes_install/includes_install_common_uid_max.rst
@@ -3,11 +3,19 @@
 
 The installation process for the |chef server| requires the use of at least 2 user and group identifiers (UIDs and GIDs). These are used to create the ``opscode`` and ``opscode-pgsql`` users and their default groups.
 
-.. note:: The creation of required user and group identifiers is done **automatically** during the installation process for the |chef server|; however, the following user and group accounts **may** be created in advance of installing the |chef server| if specific UIDs and/or GIDs are preferred.
+.. note:: The creation of required user and group identifiers is done **automatically** during the installation process for the |chef server|; however, the following user and group accounts **may** be created in advance of installing the |chef server| if specific UIDs and GIDs are preferred. The user AND group must be created as a pair to satisfy reconfiguration requirements.
 
-   * A local user account under which services will run
-   * A local user account for |postgresql|
-   * A group account under which services will run
+   * A local user account under which services will run, opscode
+   * A local user account for |postgresql|, opscode-pgsql
+   * A group account for each user under which services will run, opscode and opscode-pgsql
+
+   The embedded Chef Server cookbooks can handle two cases
+
+   * Both opscode and opscode-pgsql user and group not found on the new server
+   * Both opscode and opscode-pgsql user and group found on the new server
+
+   Having only the group and not the corresponding users present during a chef-server-ctl reconfigure is unsupported
+   and leads to an error in the reconfiguration run.
 
    To determine the current range of IDs, run the following command:
 

--- a/includes_system_requirements/includes_system_requirements_server_etc.rst
+++ b/includes_system_requirements/includes_system_requirements_server_etc.rst
@@ -11,8 +11,8 @@ Before installing the |chef server|, ensure that each machine has the following 
 * **git** --- |git| must be installed so that various internal services can confirm revisions
 * **libfreetype and libpng** --- These libraries are required
 * **Apache Qpid** --- This daemon must be disabled on |centos| and |redhat| systems
-* **Required users** --- If the environment in which the |chef server| will run has restrictions on the creation of local user and group accounts, ensure that the correct users already exist
-* **Firewalls and ports** --- If host-based firewalls (iptables, ufw, etc.) are being used, ensure that ports 80 and 443 are open. These ports are used by the |service nginx| service.
+* **Required users** --- If the environment in which the |chef server| will run has restrictions on the creation of local user and group accounts, ensure that the correct users and groups exist before reconfiguring
+* **Firewalls and ports** --- If host-based firewalls (iptables, ufw, etc.) are being used, ensure that ports 80 and 443 are open. These ports are used by the |service nginx| service
 * **Hostname** --- The hostname for the |chef server| must be a |fqdn|, including the domain suffix, and must be resolvable. See `Hostnames, FQDNs <http://docs.chef.io/install_server_pre.html#about-the-hostname>`_ for more information
 
 In addition:


### PR DESCRIPTION
Either both the user and group are created, or not at all.
Clarify this point in the docs.

The embedded Chef Server cookbooks can handle two cases
- opscode user and opscode group not found
- Both opscode user and opscode group found

Having only the opscode group present during a chef-server-ctl reconfigure is unsupported
and leads to an error in the reconfiguration run.
