### PR TITLE
Explicitly Mark AppArmor Like SELinux

### DIFF
--- a/chef_master/source/install_server_pre.rst
+++ b/chef_master/source/install_server_pre.rst
@@ -26,6 +26,10 @@ UIDs and GIDs
 =====================================================
 .. include:: ../../includes_install/includes_install_common_selinux.rst
 
+|apparmor|
+=====================================================
+.. include:: ../../includes_install/includes_install_common_apparmor.rst
+
 |apache qpid|
 =====================================================
 .. include:: ../../includes_install/includes_install_common_apache_qpid.rst

--- a/includes_install/includes_install_common_apparmor.rst
+++ b/includes_install/includes_install_common_apparmor.rst
@@ -1,0 +1,31 @@
+.. The contents of this file are included in multiple topics.
+.. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets. 
+
+On |ubuntu| systems, |apparmor| is enabled in enforcing mode by default. |chef| products do not have a profile available to run under |apparmor|. In order for the |chef| products to run, |apparmor| must set to ``Complaining`` mode or disabled.
+
+To determine if |apparmor| is installed, run the following command:
+
+.. code-block:: bash
+
+   $ sudo apparmor_status
+
+If a response other than ``"0 processes are in enforce mode"`` or ``"0 profiles are in enforce mode."`` is returned, |apparmor| must be set to ``Complaining`` mode or disabled.
+
+To set |apparmor| to ``Complaining`` mode, run:
+
+.. code-block:: bash
+
+   $ sudo aa-complain /etc/apparmor.d/*
+
+Or to disable |apparmor| entirely, run:
+
+.. code-block:: bash
+
+   $ sudo invoke-rc.d apparmor kill
+   $ sudo update-rc.d -f apparmor remove
+
+and then check the status:
+
+.. code-block:: bash
+
+   $ sudo apparmor_status

--- a/swaps/swap_names.txt
+++ b/swaps/swap_names.txt
@@ -19,6 +19,7 @@
 .. |api delivery| replace:: Delivery API
 .. |api omnitruck| replace:: Omnitruck API
 .. |api push jobs| replace:: Push Jobs API
+.. |apparmor| replace:: AppArmor
 .. |bento| replace:: Bento
 .. |busser| replace:: Busser
 .. |chef| replace:: Chef


### PR DESCRIPTION
AppArmor, like SELinux, is problematic.
Chef does not create or test profiles for
these mandatory access control systems
for any of our products on any OS. They must be disabled
with regards to Chef products until that fact changes
