### PR TITLE
Clarify Push Jobs Port Requirements

### DIFF
--- a/includes_config/includes_config_rb_push_jobs_server_settings.rst
+++ b/includes_config/includes_config_rb_push_jobs_server_settings.rst
@@ -9,10 +9,8 @@ This configuration file has the following settings:
 
    * - Setting
      - Description
-   * - ``api_port``
-     - The port used by the |api push jobs|. Default: 10003
    * - ``command_port``
-     - The port on which a |push jobs| server listens for requests that are to be executed on managed nodes. Default: 10002
+     - The port on which a |push jobs| server listens for requests that are to be executed on managed nodes. Default: 10003
    * - ``heartbeat_interval``
      - The frequency of the |push jobs| server heartbeat message. Default: 1000 (milliseconds)
    * - ``server_heartbeat_port``

--- a/includes_install/includes_install_push_jobs_server.rst
+++ b/includes_install/includes_install_push_jobs_server.rst
@@ -11,7 +11,7 @@ To set up the |push jobs| server for a standalone configuration:
 
    This step is required on each of the servers in the |chef server| deployment. For example, in a configuration with two backend servers and three frontend servers, this command would need to be run on all five servers.
 
-#. TCP protocol ports 10000-10003 must be open. This allows the |push jobs| clients to communicate with the |push jobs| server. In a configuration with both frontend and backend servers, these ports only need to be open on the backend servers. The |push jobs| server waits for connections from the |push jobs| client (and never makes a connection to a |push jobs| client).
+#. TCP protocol ports 10000 and 10003 must be open. These are the heartbeat and command ports respectively. They allow the |push jobs| server to communicate with the |push jobs| clients. In a configuration with both frontend and backend servers, these ports only need to be open on the backend servers. The |push jobs| server waits for connections from the |push jobs| client (and never makes a connection to a |push jobs| client).
 
 #. Reconfigure the |push jobs| servers:
 

--- a/includes_install/includes_install_push_jobs_server_ha.rst
+++ b/includes_install/includes_install_push_jobs_server_ha.rst
@@ -27,7 +27,7 @@ To set up the |push jobs| server for a high availability configuration:
       
       $ scp -r /etc/opscode-push-jobs-server <each servers IP>:/etc
 
-#. TCP protocol ports 10000-10003 must be open. This allows the |push jobs| clients to communicate with the |push jobs| server. In a configuration with both frontend and backend servers, these ports only need to be open on the backend servers. The |push jobs| server waits for connections from the |push jobs| client (and never makes a connection to a |push jobs| client).
+#. TCP protocol ports 10000 and 10003 must be open. These are the heartbeat and command ports respectively. They allow the |push jobs| server to communicate with the |push jobs| clients. In a configuration with both frontend and backend servers, these ports only need to be open on the backend servers. The |push jobs| server waits for connections from the |push jobs| client (and never makes a connection to a |push jobs| client).
 
 #. Reconfigure the remaining |push jobs| servers:
 

--- a/includes_server_firewalls_and_ports/includes_server_firewalls_and_ports_push_jobs.rst
+++ b/includes_server_firewalls_and_ports/includes_server_firewalls_and_ports_push_jobs.rst
@@ -1,4 +1,4 @@
 .. The contents of this file are included in multiple topics.
 .. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
 
-For communication between |push jobs| and the |chef server|, ensure that TCP protocol ports 10000-10003 are open. This allows the |push jobs| clients to communicate with the |push jobs| server. In a configuration with both front and back ends, these ports only need to be open on the back end servers. The |push jobs| server waits for connections from the |push jobs| client (and never makes a connection to a |push jobs| client).
+TCP protocol ports 10000 and 10003 must be open. These are the heartbeat and command ports respectively. This allows the |push jobs| clients to communicate with the |push jobs| server. In a configuration with both front and back ends, these ports only need to be open on the back end servers. The |push jobs| server waits for connections from the |push jobs| client (and never makes a connection to a |push jobs| client).


### PR DESCRIPTION
Only tcp port 10000 and 10003 are necessary for controlling
and communicating with push jobs clients. These are the
heartbeat and command ports respectively.
