### PR TITLE
Adds another missing reference to force_default and force_override

### DIFF
--- a/chef_master/translate/ohai.pot
+++ b/chef_master/translate/ohai.pot
@@ -233,7 +233,7 @@ msgstr ""
 
 #: ../../includes_node/includes_node_attribute_persistence.rst:4
 # bbd8c7724724430bb22120642ce0e2ed
-msgid "At the beginning of a |chef client| run, all default, override, force_default, force_override, and automatic attributes are reset. Only the normal attributes persist. The |chef client| rebuilds them using data collected by |ohai| at the beginning of the |chef client| run and by attributes that are defined in cookbooks, roles, and environments. Normal attributes are never reset. All attributes are then merged and applied to the node according to attribute precedence. At the conclusion of the |chef client| run, all default, override, and automatic attributes disappear, leaving only a collection of normal attributes that will persist until the next |chef client| run."
+msgid "At the beginning of a |chef client| run, all default, override, force_default, force_override, and automatic attributes are reset. Only the normal attributes persist. The |chef client| rebuilds them using data collected by |ohai| at the beginning of the |chef client| run and by attributes that are defined in cookbooks, roles, and environments. Normal attributes are never reset. All attributes are then merged and applied to the node according to attribute precedence. At the conclusion of the |chef client| run, all default, override, force_default, force_override and automatic attributes disappear, leaving only a collection of normal attributes that will persist until the next |chef client| run."
 msgstr ""
 
 #: ../source/ohai.rst:29


### PR DESCRIPTION
In the last pull request, I failed to see that the last sentence also need to mention force_default and force_override. This fixes that. 
