### PR TITLE
Added configuration option to manage for org_creation_enabled

### DIFF
--- a/includes_config/includes_config_rb_manage_settings.rst
+++ b/includes_config/includes_config_rb_manage_settings.rst
@@ -25,6 +25,8 @@ This configuration file has the following settings:
      - The log level for |ruby on rails| services. Default value: ``info``.
    * - ``nginx_addon_prefix``
      - The prefix used by |chef manage|. Default value: ``30``.
+   * - ``org_creation_enabled``
+     - Whether or not users can create new organizations from Manage.  Default value: ``true``.
    * - ``platform.user``
      - The name of the privileged user that manages requests to the |chef server|. Default value: ``'pivotal'``.
    * - ``platform.key_file``


### PR DESCRIPTION
A configuration option that adds the ability to disable org creation from Manage.
