### PR TITLE
Update oc-id vip default setting

### DIFF
--- a/includes_config/includes_config_rb_server_settings_oc_id.rst
+++ b/includes_config/includes_config_rb_server_settings_oc_id.rst
@@ -47,6 +47,6 @@ This configuration file has the following settings for ``oc-id``:
    * - ``oc_id['sql_user']``
      - |user ocid| Default value: ``oc_id``.
    * - ``oc_id['vip']``
-     - |ip_address virtual| Default value: ``"127.0.0.1"``.
+     - |ip_address virtual| Default value: ``"localhost"``.
 
 


### PR DESCRIPTION
This setting has changed from 127.0.0.1 to localhost to ensure IPv6
support works as expected.

DO NOT MERGE UNTIL NEXT SERVER RELEASE 

This change won't happen until the next server release, likely 12.2
