### PR TITLE
Link to test-kitchen berks+local example

### DIFF
--- a/chef_master/source/kitchen.rst
+++ b/chef_master/source/kitchen.rst
@@ -50,7 +50,4 @@ For more information about test-driven development and |kitchen|:
 
 * `Test-Driven Infrastructure with Chef, 2nd Edition <http://shop.oreilly.com/product/0636920030973.do>`_, by Stephen Nelson-Smith (O'Reilly Media)
 * `kitchen.ci <http://kitchen.ci>`_
-
-
-
-
+* `How Can I Combine Berks and Local Cookbooks? <https://coderwall.com/p/j72egw/organise-your-site-cookbooks-with-berkshelf-and-this-trick>`_


### PR DESCRIPTION
Let's update with a way to use both berks cookbooks and local customer cookbooks in their own directories
