### PR TITLE
Add ps credential

### DIFF
--- a/includes_resources/includes_resource_dsc_script_helper_ps_credential.rst
+++ b/includes_resources/includes_resource_dsc_script_helper_ps_credential.rst
@@ -1,0 +1,29 @@
+.. The contents of this file are included in multiple topics.
+.. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
+
+
+Use the ``ps_credential`` helper to embed a ``PSCredential`` object---security credentials, such as a user name or password---within a script.
+
+For example, assuming the ``CertificateID`` is configured in the local configuration manager, the ``SeaPower1@3`` object is created and embedded within the ``seapower-user`` script:
+
+.. code-block:: ruby
+
+   dsc_script 'seapower-user' do
+     code <<-EOH
+       User AlbertAtom
+       {
+         UserName = 'AlbertAtom'
+         Password = #{ps_credential('SeaPower1@3')}
+       }
+    EOH
+    configuration_data <<-EOH
+      @{
+        AllNodes = @(
+          @{
+            NodeName = "localhost";
+            CertificateID = 'A8D1234559F349F7EF19104678908F701D4167'
+          }
+        )
+      }
+    EOH
+  end

--- a/release_chef_12-2/source/resource_dsc_script.rst
+++ b/release_chef_12-2/source/resource_dsc_script.rst
@@ -1,4 +1,60 @@
-.. THIS PAGE IS IDENTICAL TO docs.chef.io/resource_dsc_script.html BY DESIGN
 .. THIS PAGE DOCUMENTS chef-client version 12.2
 
-.. include:: ../../chef_master/source/resource_dsc_script.rst
+=====================================================
+dsc_script
+=====================================================
+
+.. include:: ../../includes_resources_common/includes_resources_common_generic.rst
+
+.. include:: ../../includes_resources_common/includes_resources_common_powershell.rst
+
+.. include:: ../../includes_resources_common/includes_resources_common_powershell_dsc.rst
+
+.. include:: ../../includes_resources/includes_resource_dsc_script.rst
+
+.. note:: |windows powershell| 4.0 is required for using the |resource dsc_script| resource with |chef|.
+
+.. note:: The |windows remote management| service must be enabled. (Use ``winrm quickconfig`` to enable the service.)
+
+.. warning:: The |resource dsc_script| resource  may not be used in the same run-list with the |resource dsc_resource|. This is because the |resource dsc_script| resource requires that ``RefreshMode`` in the Local Configuration Manager be set to ``Push``, whereas the |resource dsc_resource| resource requires it to be set to ``Disabled``.
+
+Syntax
+=====================================================
+.. include:: ../../includes_resources/includes_resource_dsc_script_syntax.rst
+
+Actions
+=====================================================
+.. include:: ../../includes_resources/includes_resource_dsc_script_actions.rst
+
+Properties
+=====================================================
+.. include:: ../../includes_resources/includes_resource_dsc_script_attributes.rst
+
+Examples
+=====================================================
+|generic resource statement|
+
+**Specify DSC code directly**
+
+.. include:: ../../step_resource/step_resource_dsc_script_code.rst
+
+**Specify DSC code using a Windows Powershell data file**
+
+.. include:: ../../step_resource/step_resource_dsc_script_command.rst
+
+**Pass parameters to DSC configurations**
+
+.. include:: ../../step_resource/step_resource_dsc_script_flags.rst
+
+**Use custom configuration data**
+
+.. include:: ../../includes_resources/includes_resource_dsc_script_custom_config_data.rst
+
+.. include:: ../../step_resource/step_resource_dsc_script_configuration_data.rst
+
+.. include:: ../../step_resource/step_resource_dsc_script_configuration_name.rst
+
+**Using DSC with other Chef resources**
+
+.. include:: ../../step_resource/step_resource_dsc_script_remote_files.rst
+

--- a/release_chef_12-3/source/resource_dsc_script.rst
+++ b/release_chef_12-3/source/resource_dsc_script.rst
@@ -1,4 +1,60 @@
-.. THIS PAGE IS IDENTICAL TO docs.chef.io/resource_dsc_script.html BY DESIGN
 .. THIS PAGE DOCUMENTS chef-client version 12.3
 
-.. include:: ../../chef_master/source/resource_dsc_script.rst
+=====================================================
+dsc_script
+=====================================================
+
+.. include:: ../../includes_resources_common/includes_resources_common_generic.rst
+
+.. include:: ../../includes_resources_common/includes_resources_common_powershell.rst
+
+.. include:: ../../includes_resources_common/includes_resources_common_powershell_dsc.rst
+
+.. include:: ../../includes_resources/includes_resource_dsc_script.rst
+
+.. note:: |windows powershell| 4.0 is required for using the |resource dsc_script| resource with |chef|.
+
+.. note:: The |windows remote management| service must be enabled. (Use ``winrm quickconfig`` to enable the service.)
+
+.. warning:: The |resource dsc_script| resource  may not be used in the same run-list with the |resource dsc_resource|. This is because the |resource dsc_script| resource requires that ``RefreshMode`` in the Local Configuration Manager be set to ``Push``, whereas the |resource dsc_resource| resource requires it to be set to ``Disabled``.
+
+Syntax
+=====================================================
+.. include:: ../../includes_resources/includes_resource_dsc_script_syntax.rst
+
+Actions
+=====================================================
+.. include:: ../../includes_resources/includes_resource_dsc_script_actions.rst
+
+Properties
+=====================================================
+.. include:: ../../includes_resources/includes_resource_dsc_script_attributes.rst
+
+Examples
+=====================================================
+|generic resource statement|
+
+**Specify DSC code directly**
+
+.. include:: ../../step_resource/step_resource_dsc_script_code.rst
+
+**Specify DSC code using a Windows Powershell data file**
+
+.. include:: ../../step_resource/step_resource_dsc_script_command.rst
+
+**Pass parameters to DSC configurations**
+
+.. include:: ../../step_resource/step_resource_dsc_script_flags.rst
+
+**Use custom configuration data**
+
+.. include:: ../../includes_resources/includes_resource_dsc_script_custom_config_data.rst
+
+.. include:: ../../step_resource/step_resource_dsc_script_configuration_data.rst
+
+.. include:: ../../step_resource/step_resource_dsc_script_configuration_name.rst
+
+**Using DSC with other Chef resources**
+
+.. include:: ../../step_resource/step_resource_dsc_script_remote_files.rst
+

--- a/release_chef_12-4/source/resource_dsc_script.rst
+++ b/release_chef_12-4/source/resource_dsc_script.rst
@@ -1,4 +1,60 @@
-.. THIS PAGE IS IDENTICAL TO docs.chef.io/resource_dsc_script.html BY DESIGN
 .. THIS PAGE DOCUMENTS chef-client version 12.4
 
-.. include:: ../../chef_master/source/resource_dsc_script.rst
+=====================================================
+dsc_script
+=====================================================
+
+.. include:: ../../includes_resources_common/includes_resources_common_generic.rst
+
+.. include:: ../../includes_resources_common/includes_resources_common_powershell.rst
+
+.. include:: ../../includes_resources_common/includes_resources_common_powershell_dsc.rst
+
+.. include:: ../../includes_resources/includes_resource_dsc_script.rst
+
+.. note:: |windows powershell| 4.0 is required for using the |resource dsc_script| resource with |chef|.
+
+.. note:: The |windows remote management| service must be enabled. (Use ``winrm quickconfig`` to enable the service.)
+
+.. warning:: The |resource dsc_script| resource  may not be used in the same run-list with the |resource dsc_resource|. This is because the |resource dsc_script| resource requires that ``RefreshMode`` in the Local Configuration Manager be set to ``Push``, whereas the |resource dsc_resource| resource requires it to be set to ``Disabled``.
+
+Syntax
+=====================================================
+.. include:: ../../includes_resources/includes_resource_dsc_script_syntax.rst
+
+Actions
+=====================================================
+.. include:: ../../includes_resources/includes_resource_dsc_script_actions.rst
+
+Properties
+=====================================================
+.. include:: ../../includes_resources/includes_resource_dsc_script_attributes.rst
+
+Examples
+=====================================================
+|generic resource statement|
+
+**Specify DSC code directly**
+
+.. include:: ../../step_resource/step_resource_dsc_script_code.rst
+
+**Specify DSC code using a Windows Powershell data file**
+
+.. include:: ../../step_resource/step_resource_dsc_script_command.rst
+
+**Pass parameters to DSC configurations**
+
+.. include:: ../../step_resource/step_resource_dsc_script_flags.rst
+
+**Use custom configuration data**
+
+.. include:: ../../includes_resources/includes_resource_dsc_script_custom_config_data.rst
+
+.. include:: ../../step_resource/step_resource_dsc_script_configuration_data.rst
+
+.. include:: ../../step_resource/step_resource_dsc_script_configuration_name.rst
+
+**Using DSC with other Chef resources**
+
+.. include:: ../../step_resource/step_resource_dsc_script_remote_files.rst
+

--- a/release_chef_12-5/source/release_notes.rst
+++ b/release_chef_12-5/source/release_notes.rst
@@ -9,22 +9,16 @@ What's New
 The following items are new for |chef client| 12.5 and/or are changes from previous versions. The short version:
 
 * **Rename "resource attributes" to "resource properties"** One of the outcomes of `RFC-054 <https://github.com/chef/chef-rfc/blob/master/rfc054-resource-attribute-improvements.md>`__ is that |company_name| will be more clear about what a node attribute is versus a resource property. In previous releases of |chef|, resource properties are referred to as attributes. Starting with |chef client| 12.5 (and retroactively updated for all previous releases of the docs), "resource attributes" will now be referred to as "resource properties". This is a semantic change in the docs that makes it more clear for everyone---they should have been called "resource properties" originally---but otherwise does not change any workflows or break anything.
+* **ps_credential helper to embed usernames and passwords** Use the ``ps_credential`` helper to embed a ``PSCredential`` object---security credentials, such as a user name or password---in a script defined by the |resource dsc_script| resource.
 * **The terms LWRP and HWRP are deprecated** The new way to refer to creating a custom resource is "custom resource" and the acronymns LWRP ("lightweight resource provider") and HWRP ("heavyweight resource provider") are deprecated. They are older, legacy terms that refer to specific ways of building custom resources. The current version of |chef| supports the older lightweight/heavyweight approaches, but adds additional ways of building custom resources.
-* **xxxxx** xxxxx
-* **xxxxx** xxxxx
-* **xxxxx** xxxxx
 
-xxxxx
+``ps_credential`` Helper
 -----------------------------------------------------
-xxxxx
+.. include:: ../../includes_resources/includes_resource_dsc_script_helper_ps_credential.rst
 
-xxxxx
+Custom Resources
 -----------------------------------------------------
-xxxxx
-
-xxxxx
------------------------------------------------------
-xxxxx
+The |chef client| 12.5 release includes a new way of creating custom resources.
 
 Changelog
 =====================================================

--- a/release_chef_12-5/source/resource_dsc_script.rst
+++ b/release_chef_12-5/source/resource_dsc_script.rst
@@ -1,4 +1,65 @@
 .. THIS PAGE IS IDENTICAL TO docs.chef.io/resource_dsc_script.html BY DESIGN
 .. THIS PAGE DOCUMENTS chef-client version 12.5
 
-.. include:: ../../chef_master/source/resource_dsc_script.rst
+=====================================================
+dsc_script
+=====================================================
+
+.. include:: ../../includes_resources_common/includes_resources_common_generic.rst
+
+.. include:: ../../includes_resources_common/includes_resources_common_powershell.rst
+
+.. include:: ../../includes_resources_common/includes_resources_common_powershell_dsc.rst
+
+.. include:: ../../includes_resources/includes_resource_dsc_script.rst
+
+.. note:: |windows powershell| 4.0 is required for using the |resource dsc_script| resource with |chef|.
+
+.. note:: The |windows remote management| service must be enabled. (Use ``winrm quickconfig`` to enable the service.)
+
+.. warning:: The |resource dsc_script| resource  may not be used in the same run-list with the |resource dsc_resource|. This is because the |resource dsc_script| resource requires that ``RefreshMode`` in the Local Configuration Manager be set to ``Push``, whereas the |resource dsc_resource| resource requires it to be set to ``Disabled``.
+
+Syntax
+=====================================================
+.. include:: ../../includes_resources/includes_resource_dsc_script_syntax.rst
+
+Actions
+=====================================================
+.. include:: ../../includes_resources/includes_resource_dsc_script_actions.rst
+
+Properties
+=====================================================
+.. include:: ../../includes_resources/includes_resource_dsc_script_attributes.rst
+
+``ps_credential`` Helper
+-----------------------------------------------------
+.. include:: ../../includes_resources/includes_resource_dsc_script_helper_ps_credential.rst
+
+Examples
+=====================================================
+|generic resource statement|
+
+**Specify DSC code directly**
+
+.. include:: ../../step_resource/step_resource_dsc_script_code.rst
+
+**Specify DSC code using a Windows Powershell data file**
+
+.. include:: ../../step_resource/step_resource_dsc_script_command.rst
+
+**Pass parameters to DSC configurations**
+
+.. include:: ../../step_resource/step_resource_dsc_script_flags.rst
+
+**Use custom configuration data**
+
+.. include:: ../../includes_resources/includes_resource_dsc_script_custom_config_data.rst
+
+.. include:: ../../step_resource/step_resource_dsc_script_configuration_data.rst
+
+.. include:: ../../step_resource/step_resource_dsc_script_configuration_name.rst
+
+**Using DSC with other Chef resources**
+
+.. include:: ../../step_resource/step_resource_dsc_script_remote_files.rst
+


### PR DESCRIPTION
This adds a topic for ps_credential, a new helper for chef-client 12.5. This hooks it into the 12.5 docs (release notes and dsc_script topics). And then versions the 12.2, 12.3, and 12.4 dsc_script topics so that they do not include the ps_credential topic.
