### PR TITLE
Update link to Foodcritic web page.

### DIFF
--- a/chef_master/source/foodcritic.rst
+++ b/chef_master/source/foodcritic.rst
@@ -34,4 +34,4 @@ For more information ...
 =====================================================
 For more information about |foodcritic|:
 
-* `http://acrmp.github.io/foodcritic/ <http://acrmp.github.io/foodcritic/>`_
+* `http://www.foodcritic.io/ <http://www.foodcritic.io/>`_


### PR DESCRIPTION
I've updated link to Foodcritic web page:
http://acrmp.github.io/foodcritic => http://www.foodcritic.io/
