### PR TITLE
Update bash resource to include warning about using the path property

### DIFF
--- a/includes_resources/includes_resource_script_bash_attributes.rst
+++ b/includes_resources/includes_resource_script_bash_attributes.rst
@@ -49,6 +49,8 @@ This resource has the following properties:
      - **Ruby Type:** Array
 
        |path resource execute| The default value uses the system path.
+
+       .. warning:: .. include:: ../../includes_resources_common/includes_resources_common_resource_execute_attribute_path.rst
    * - ``provider``
      - **Ruby Type:** Chef Class
 


### PR DESCRIPTION
Do you want me to also include this same warning for any of the csh, ruby, python, etc. resources too?
