### PR TITLE
Remove "sudo may be required" in your home dir

### DIFF
--- a/includes_install/includes_install_chef_client_repo_manual_chef_directory.rst
+++ b/includes_install/includes_install_chef_client_repo_manual_chef_directory.rst
@@ -15,9 +15,7 @@ To create the |chef repo hidden| directory:
 
    .. code-block:: bash
 
-      sudo mkdir -p ~/chef-repo/.chef
-
-   .. note:: ``sudo`` is not always required, but it often is.
+      mkdir -p ~/chef-repo/.chef
 
 #. After the |chef repo hidden| directory has been created, the following folder structure will be present on the local machine::
 


### PR DESCRIPTION
The command to create the `.chef` directory includes `sudo` and says it may be required. This would never be the case in your own home directory and would likely lead to problems if the user followed this instruction because the directory would then be owned by root.
