### PR TITLE
reboot resource's delay_mins gets minutes not seconds

### DIFF
--- a/includes_resources/includes_resource_service_reboot_attributes.rst
+++ b/includes_resources/includes_resource_service_reboot_attributes.rst
@@ -12,9 +12,9 @@ This resource has the following properties:
    * - ``delay_mins``
      - **Ruby Type:** Fixnum
 
-       The amount of time (in seconds) to delay a reboot request.
+       The amount of time (in minutes) to delay a reboot request.
 
-       .. note:: This setting must be entered in seconds.
+       .. note:: This setting must be entered in minutes.
 
    * - ``ignore_failure``
      - **Ruby Types:** TrueClass, FalseClass


### PR DESCRIPTION
https://github.com/chef/chef/blob/master/lib/chef/platform/rebooter.rb#L33-L39
