### PR TITLE
Updates for GitHub

### DIFF
--- a/.delivery/build-cookbook/recipes/publish.rb
+++ b/.delivery/build-cookbook/recipes/publish.rb
@@ -50,7 +50,7 @@ template File.join(node['delivery']['workspace']['repo'], 'cookbooks', 'docs-bui
     build_name: build_name,
     bucket_name: artifact_bucket,
     ssh_key: File.read('/var/opt/delivery/workspace/etc/builder_key'),
-    repo_location: 'ssh://builder@chef@delivery.chef.co:8989/chef/CIA/chef-web-docs',
+    repo_location: 'https://github.com/chef/chef-web-docs.git',
     cached: true
   )
   sensitive true

--- a/.delivery/build-cookbook/templates/default/.kitchen.delivery.yml.erb
+++ b/.delivery/build-cookbook/templates/default/.kitchen.delivery.yml.erb
@@ -39,4 +39,4 @@ suites:
       build_aws_access_key: <%= @chef_aws_access_key  %>
       build_aws_secret_access_key: <%= @chef_aws_secret_key %>
       repo_location: <%= @repo_location %>
-      cached: true
+      cached: false

--- a/.delivery/config.json
+++ b/.delivery/config.json
@@ -7,10 +7,5 @@
   "skip_phases": [
     "quality",
     "security"
-  ],
-  "delivery-truck": {
-    "publish": {
-      "github": "chef/chef-web-docs"
-    }
-  }
+  ]
 }


### PR DESCRIPTION
- Disables the publish to GitHub since we are already here
- Uses GitHub for the repo location during the build
- Disables caching on the builder node
