### PR TITLE
Use the cache value from the recipe

### DIFF
--- a/.delivery/build-cookbook/templates/default/.kitchen.delivery.yml.erb
+++ b/.delivery/build-cookbook/templates/default/.kitchen.delivery.yml.erb
@@ -39,4 +39,4 @@ suites:
       build_aws_access_key: <%= @chef_aws_access_key  %>
       build_aws_secret_access_key: <%= @chef_aws_secret_key %>
       repo_location: <%= @repo_location %>
-      cached: false
+      cached: <%= @cached %>


### PR DESCRIPTION
When building the site we want to be able to toggle on and off caching.
This should be set in the recipe that defines the template, not in the
template itself.
