### PR TITLE
Remove scss causing unwanted horizontal scrolbars

### DIFF
--- a/_themes/chefv2/static/chefv2.css_t
+++ b/_themes/chefv2/static/chefv2.css_t
@@ -381,8 +381,7 @@ div.topic {
 
 /* -- table styles */
 div.section {
-  max-width: 100%;
-  overflow-x: scroll; }
+  max-width: 100%; }
 
 table.docutils {
   max-width: 100%;

--- a/_themes/chefv2/static/scss/_sphinx.scss
+++ b/_themes/chefv2/static/scss/_sphinx.scss
@@ -388,7 +388,6 @@ div.topic {
 /* -- table styles */
 div.section {
     max-width: 100%;
-    overflow-x: scroll;
 }
 
 table.docutils {


### PR DESCRIPTION
On a few Windows browsers (IE and Firefox), the overflow-x:scroll declaration was causing unwanted horizontal scrollbars, even when the content was not overflowing.
