### PR TITLE
Ensure chef server fqdn is all lowercase

### DIFF
--- a/chef_master/source/install_server_pre.rst
+++ b/chef_master/source/install_server_pre.rst
@@ -54,7 +54,11 @@ Use the following sections to verify the hostnames that is used by the |chef ser
 
 .. include:: ../../includes_install/includes_install_common_hostname_is_fqdn.rst
 
-**To verify is a hostname is resolvable**
+**To very the FQDN is all lowercase**
+
+.. include:: ../../includes_install/includes_install_common_hostname_is_lowercase.rst
+
+**To verify a hostname is resolvable**
 
 .. include:: ../../includes_install/includes_install_common_hostname_is_resolvable.rst
 

--- a/includes_install/includes_install_common_hostname_is_lowercase.rst
+++ b/includes_install/includes_install_common_hostname_is_lowercase.rst
@@ -1,0 +1,17 @@
+.. This is an included how-to. 
+
+
+To verify if the alphabetic parts of a |fqdn| are all lowercase, run the following command:
+
+.. code-block:: bash
+
+   $ hostname -f | grep -E '^([[:digit:]]|[[:lower:]]|\.|-|_)+$' && echo yes
+
+If the hostname is all lowercase, it will return something like:
+
+.. code-block:: bash
+
+   mychefserver.example.com
+   yes
+
+If the hostname's alphabetic parts are not all lowercase, it must be configured so that they are.


### PR DESCRIPTION
On unix systems, the hostname is always all lowercase alphabetic characters.
Provided a prereqs check for this status.
