### PR TITLE
Move multi-key entries to global endpoints

### DIFF
--- a/chef_master/source/api_chef_server.rst
+++ b/chef_master/source/api_chef_server.rst
@@ -140,7 +140,33 @@ PUT
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 .. include:: ../../includes_api_chef_server/includes_api_chef_server_endpoint_user_put.rst
 
+/user/USER/keys/
+-----------------------------------------------------
+.. include:: ../../includes_api_chef_server/includes_api_chef_server_endpoint_keys_users.rst
 
+GET
++++++++++++++++++++++++++++++++++++++++++++++++++++++
+.. include:: ../../includes_api_chef_server/includes_api_chef_server_endpoint_keys_users_get.rst
+
+POST
++++++++++++++++++++++++++++++++++++++++++++++++++++++
+.. include:: ../../includes_api_chef_server/includes_api_chef_server_endpoint_keys_users_post.rst
+
+/user/USER/keys/KEY
+-----------------------------------------------------
+.. include:: ../../includes_api_chef_server/includes_api_chef_server_endpoint_key_user.rst
+
+DELETE
++++++++++++++++++++++++++++++++++++++++++++++++++++++
+.. include:: ../../includes_api_chef_server/includes_api_chef_server_endpoint_key_user_delete.rst
+
+GET
++++++++++++++++++++++++++++++++++++++++++++++++++++++
+.. include:: ../../includes_api_chef_server/includes_api_chef_server_endpoint_key_user_get.rst
+
+PUT
++++++++++++++++++++++++++++++++++++++++++++++++++++++
+.. include:: ../../includes_api_chef_server/includes_api_chef_server_endpoint_key_user_put.rst
 
 
 
@@ -638,34 +664,6 @@ GET
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 .. include:: ../../includes_api_chef_server/includes_api_chef_server_endpoint_org_name_updated_since_get.rst
 
-
-/user/USER/keys/
------------------------------------------------------
-.. include:: ../../includes_api_chef_server/includes_api_chef_server_endpoint_keys_users.rst
-
-GET
-+++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. include:: ../../includes_api_chef_server/includes_api_chef_server_endpoint_keys_users_get.rst
-
-POST
-+++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. include:: ../../includes_api_chef_server/includes_api_chef_server_endpoint_keys_users_post.rst
-
-/user/USER/keys/KEY
------------------------------------------------------
-.. include:: ../../includes_api_chef_server/includes_api_chef_server_endpoint_key_user.rst
-
-DELETE
-+++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. include:: ../../includes_api_chef_server/includes_api_chef_server_endpoint_key_user_delete.rst
-
-GET
-+++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. include:: ../../includes_api_chef_server/includes_api_chef_server_endpoint_key_user_get.rst
-
-PUT
-+++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. include:: ../../includes_api_chef_server/includes_api_chef_server_endpoint_key_user_put.rst
 
 
 

--- a/includes_api_chef_server/includes_api_chef_server_endpoint_key_user_delete.rst
+++ b/includes_api_chef_server/includes_api_chef_server_endpoint_key_user_delete.rst
@@ -9,7 +9,7 @@ This method has no parameters.
 
 .. code-block:: xml
 
-   DELETE /organizations/NAME/users/USER/keys/KEY
+   DELETE /users/USER/keys/KEY
 
 **Response**
 

--- a/includes_api_chef_server/includes_api_chef_server_endpoint_key_user_get.rst
+++ b/includes_api_chef_server/includes_api_chef_server_endpoint_key_user_get.rst
@@ -9,7 +9,7 @@ This method has no parameters.
 
 .. code-block:: xml
 
-   GET /organizations/NAME/users/USER/keys/KEY
+   GET /users/USER/keys/KEY
 
 **Response**
 

--- a/includes_api_chef_server/includes_api_chef_server_endpoint_key_user_put.rst
+++ b/includes_api_chef_server/includes_api_chef_server_endpoint_key_user_put.rst
@@ -9,7 +9,7 @@ This method has no parameters.
 
 .. code-block:: xml
 
-   PUT /organizations/NAME/users/USER/keys/KEY
+   PUT /users/USER/keys/KEY
 
 with a request body similar to:
 

--- a/includes_api_chef_server/includes_api_chef_server_endpoint_keys_users_get.rst
+++ b/includes_api_chef_server/includes_api_chef_server_endpoint_keys_users_get.rst
@@ -9,7 +9,7 @@ This method has no parameters.
 
 .. code-block:: xml
 
-   GET /organizations/NAME/users/USER/keys/
+   GET /users/USER/keys/
 
 **Response**
 

--- a/includes_api_chef_server/includes_api_chef_server_endpoint_keys_users_post.rst
+++ b/includes_api_chef_server/includes_api_chef_server_endpoint_keys_users_post.rst
@@ -9,7 +9,7 @@ This method has no parameters.
 
 .. code-block:: xml
 
-   POST /organizations/NAME/users/USER/keys/
+   POST /users/USER/keys/
 
 with a request body similar to:
 


### PR DESCRIPTION
The new keys endpoints work like this, where they are rooted at the chef_server_root, rather than on any particular organization. This means that they are global to the chef server, rather than per-org.

https://API_FQDN/user/USER/keys

https://API_FQDN/user/USER/keys/KEY
