### PR TITLE
Slightly incorrect instructions about quotes

### DIFF
--- a/includes_ruby/includes_ruby_style_basics_string_escape_character.rst
+++ b/includes_ruby/includes_ruby_style_basics_string_escape_character.rst
@@ -2,9 +2,9 @@
 .. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
 
 
-Use the backslash character (``\``) as an escape character when quotes must appear within strings. For example:
+Use the backslash character (``\``) as an escape character when quotes must appear within strings. However, you do not need to escape single quotes inside double quotes. For example:
 
 .. code-block:: ruby
 
    'It\'s alive!'                        # => "It's alive!"
-   "Won\'t you read Grant\'s book?"      # => "Won't you read Grant's book?"
+   "Won't you read Grant's book?"      # => "Won't you read Grant's book?"


### PR DESCRIPTION
This corrects the spurious escapes in the double-quoted string.
