### PR TITLE
Update docs to clarify the --bootstrap-vault options

### DIFF
--- a/chef_master/source/install_bootstrap.rst
+++ b/chef_master/source/install_bootstrap.rst
@@ -24,17 +24,22 @@ knife bootstrap Options
 Use the following options with a validatorless bootstrap to specify items that are stored in |chef vault|:
 
 ``--bootstrap-vault-file VAULT_FILE``
-   |bootstrap valut_file|
+   |bootstrap vault_file|
 
 ``--bootstrap-vault-item VAULT_ITEM``
-   |bootstrap valut_item|
+   |bootstrap vault_item|
 
 ``--bootstrap-vault-json VAULT_JSON``
-   |bootstrap valut_json|
+   |bootstrap vault_json|
 
 Examples
 =====================================================
-The ``--bootstrap-vault-*`` options add the client identify of the bootstrapping node to the permissions list o the specified vault item. This enables the newly-bootstrapped |chef client| to be able to read items from the vault. Only a single client is authorized at a time for acces to the vault. (The ``-S`` search query option with the ``knife vault create`` command does the same.)
+The ``--bootstrap-vault-*`` options add the client identity of the bootstrapping node to the permissions list of the specified vault item. This enables the newly-bootstrapped |chef client| to be able to read items from the vault. Only a single client is authorized at a time for access to the vault. (The ``-S`` search query option with the ``knife vault create`` command does the same.)
+
+.. note:: The vault specification passed to the options above, either
+	  directly, or through a file or passing a JSON string, will always look like its
+	  underlying databag:item form. These options are not meant to pass
+	  free-form JSON.
 
 Recreate a data bag item
 -----------------------------------------------------

--- a/chef_master/source/knife_bootstrap.rst
+++ b/chef_master/source/knife_bootstrap.rst
@@ -31,13 +31,13 @@ Validatorless Bootstrap
 Use the following options with a validatorless bootstrap to specify items that are stored in |chef vault|:
 
 ``--bootstrap-vault-file VAULT_FILE``
-   |bootstrap valut_file|
+   |bootstrap vault_file|
 
 ``--bootstrap-vault-item VAULT_ITEM``
-   |bootstrap valut_item|
+   |bootstrap vault_item|
 
 ``--bootstrap-vault-json VAULT_JSON``
-   |bootstrap valut_json|
+   |bootstrap vault_json|
 
 Custom Templates
 =====================================================

--- a/includes_config/includes_config_rb_knife_settings_optional_all.rst
+++ b/includes_config/includes_config_rb_knife_settings_optional_all.rst
@@ -45,11 +45,11 @@ The following list describes all of the optional settings that can be added to t
    * - ``knife[:bootstrap_template]``
      - |path bootstrap_template|
    * - ``knife[:bootstrap_vault_file]``
-     - |bootstrap valut_file|
+     - |bootstrap vault_file|
    * - ``knife[:bootstrap_vault_item]``
-     - |bootstrap valut_item|
+     - |bootstrap vault_item|
    * - ``knife[:bootstrap_vault_json]``
-     - |bootstrap valut_item|
+     - |bootstrap vault_item|
    * - ``knife[:bootstrap_version]``
      - |bootstrap version|
    * - ``knife[:bootstrap_wget_options]``

--- a/includes_knife/includes_knife_12-3_bootstrap_options.rst
+++ b/includes_knife/includes_knife_12-3_bootstrap_options.rst
@@ -26,13 +26,13 @@ This subcommand has the following options:
    |bootstrap proxy|
 
 ``--bootstrap-vault-file VAULT_FILE``
-   |bootstrap valut_file|
+   |bootstrap vault_file|
 
 ``--bootstrap-vault-item VAULT_ITEM``
-   |bootstrap valut_item|
+   |bootstrap vault_item|
 
 ``--bootstrap-vault-json VAULT_JSON``
-   |bootstrap valut_json|
+   |bootstrap vault_json|
 
 ``--bootstrap-version VERSION``
    |bootstrap version|

--- a/includes_knife/includes_knife_bootstrap_options.rst
+++ b/includes_knife/includes_knife_bootstrap_options.rst
@@ -26,13 +26,13 @@ This subcommand has the following options:
    |bootstrap proxy|
 
 ``--bootstrap-vault-file VAULT_FILE``
-   |bootstrap valut_file|
+   |bootstrap vault_file|
 
 ``--bootstrap-vault-item VAULT_ITEM``
-   |bootstrap valut_item|
+   |bootstrap vault_item|
 
 ``--bootstrap-vault-json VAULT_JSON``
-   |bootstrap valut_json|
+   |bootstrap vault_json|
 
 ``--bootstrap-version VERSION``
    |bootstrap version|

--- a/release_chef_12-1/source/release_notes.rst
+++ b/release_chef_12-1/source/release_notes.rst
@@ -120,13 +120,13 @@ knife bootstrap Options
 Use the following options to specify items that are stored in |chef vault|:
 
 ``--bootstrap-vault-file VAULT_FILE``
-   |bootstrap valut_file|
+   |bootstrap vault_file|
 
 ``--bootstrap-vault-item VAULT_ITEM``
-   |bootstrap valut_item|
+   |bootstrap vault_item|
 
 ``--bootstrap-vault-json VAULT_JSON``
-   |bootstrap valut_json|
+   |bootstrap vault_json|
 
 New Resource Attributes
 -----------------------------------------------------

--- a/release_chef_12-2/source/knife_bootstrap.rst
+++ b/release_chef_12-2/source/knife_bootstrap.rst
@@ -33,13 +33,13 @@ knife bootstrap Options
 Use the following options with a validatorless bootstrap to specify items that are stored in |chef vault|:
 
 ``--bootstrap-vault-file VAULT_FILE``
-   |bootstrap valut_file|
+   |bootstrap vault_file|
 
 ``--bootstrap-vault-item VAULT_ITEM``
-   |bootstrap valut_item|
+   |bootstrap vault_item|
 
 ``--bootstrap-vault-json VAULT_JSON``
-   |bootstrap valut_json|
+   |bootstrap vault_json|
 
 Custom Templates
 =====================================================

--- a/release_chef_12-3/source/knife_bootstrap.rst
+++ b/release_chef_12-3/source/knife_bootstrap.rst
@@ -33,13 +33,13 @@ knife bootstrap Options
 Use the following options with a validatorless bootstrap to specify items that are stored in |chef vault|:
 
 ``--bootstrap-vault-file VAULT_FILE``
-   |bootstrap valut_file|
+   |bootstrap vault_file|
 
 ``--bootstrap-vault-item VAULT_ITEM``
-   |bootstrap valut_item|
+   |bootstrap vault_item|
 
 ``--bootstrap-vault-json VAULT_JSON``
-   |bootstrap valut_json|
+   |bootstrap vault_json|
 
 Custom Templates
 =====================================================

--- a/swaps/swap_descriptions.txt
+++ b/swaps/swap_descriptions.txt
@@ -128,9 +128,9 @@
 .. |bootstrap no_proxy| replace:: A URL or IP address that specifies a location that should not be proxied.
 .. |bootstrap proxy| replace:: The proxy server for the node that is the target of a bootstrap operation.
 .. |bootstrap protocol| replace:: The protocol used to bootstrap on a machine that is running |windows server|: ``cloud-api``, ``ssh``, or ``winrm``.
-.. |bootstrap valut_file| replace:: The path to a |json| file that contains a list of vaults and items to be updated.
-.. |bootstrap valut_item| replace:: A single vault and item to update as ``vault:item``.
-.. |bootstrap valut_json| replace:: A |json| string that contains a list of vaults and items to be updated.
+.. |bootstrap vault_file| replace:: The path to a |json| file that contains a list of vaults and items to be updated.
+.. |bootstrap vault_item| replace:: A single vault and item to update as ``vault:item``.
+.. |bootstrap vault_json| replace:: A |json| string that contains a list of vaults and items to be updated.
 .. |bootstrap version| replace:: The version of the |chef client| to install.
 .. |bootstrap wget_options| replace:: Specify arbitrary options to be added to the bootstrap command when using |gnu wget|.
 .. |branch| replace:: The name of the default branch. This defaults to the master branch.


### PR DESCRIPTION
- Add a note to clarify the use of the --bootstrap-vault-\* options
- Fix bootstrap vault_ swap typos in the swaps file
- Fix bootstrap vault_ swap typos throughout the docs
