### PR TITLE
Add a clarification for git's :sync action

### DIFF
--- a/swaps/swap_descriptions.txt
+++ b/swaps/swap_descriptions.txt
@@ -1271,7 +1271,7 @@
 .. |resource action start service| replace:: Start a service, and keep it running until stopped or disabled.
 .. |resource action stop mdadm| replace:: Stop an active array.
 .. |resource action stop service| replace:: Stop a service.
-.. |resource action sync scm| replace:: Update the source to the specified version, or get a new clone or checkout.
+.. |resource action sync scm| replace:: Update the source to the specified version, or get a new clone or checkout. This action will hard reset the index and working tree, discarding any uncommitted changes.
 .. |resource action touch file| replace:: Touch a file. This updates the access (atime) and file modification (mtime) times for a file.
 .. |resource action umount mount| replace:: Unmount a device.
 .. |resource action unlock user| replace:: Unlock a user's password.
@@ -1764,4 +1764,3 @@
 
 .. |zenoss zenpack desc| replace:: A |zenoss zenpack| is used to add or override functionality within the |zenoss| platform.
 .. |zone google| replace:: The |google compute engine| zone in which a disk is located.
-


### PR DESCRIPTION
Add a clarification that the git resource's `:sync` action is destructive, as it [calls `git reset --hard`] on an existing clone. I had briefly mentioned I would do this to @lamont-granquist on IRC the other day, as the existing description of `:sync` says "update the source" which does not sound quite as destructive to most users.
