### PR TITLE
Wrap outbound link tracking with conditional

### DIFF
--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -54,11 +54,15 @@
   ga('send', 'pageview');
 
   var trackOutboundLink = function(url) {
-    ga('send', 'event', 'outbound', 'click', url, {'hitCallback':
-      function () {
-        document.location = url;
-      }
-    });
+    if (ga.q) {
+     document.location = url;
+    } else {
+      ga('send', 'event', 'outbound', 'click', url, {'hitCallback':
+        function () {
+          document.location = url;
+        }
+      });
+    }
   };
 </script>
 <!-- End of Async Google Analytics Code -->


### PR DESCRIPTION
In the event the GA code isn't available, any link outbound fails to
work.
Wrapping in this conditional allows links to continue to work.

/cc: @cwebberOps 
