### PR TITLE
Fix eol + remove admin user

### DIFF
--- a/step_knife/step_knife_edit_admin_users.rst
+++ b/step_knife/step_knife_edit_admin_users.rst
@@ -4,6 +4,6 @@ A user who belongs to the |webui group admins| group must be removed from the gr
 
 .. code-block:: bash
 
-   $ knife edit /group/admin.json
+   $ EDITOR=vi knife edit /groups/admins.json
 
 make the required changes, and then save the file.


### PR DESCRIPTION
The command showing removal of an admins group user in preparation for the user's deletion was incorrect/incomplete.

Also straightened out the line ending with this on OS X

```
sed -i '' -e '$a\' step_knife/step_knife_edit_admin_users.rst` 
```
