### PR TITLE
Updated link to MS official DSC resources

### DIFF
--- a/includes_resources/includes_resource_dsc_resource.rst
+++ b/includes_resources/includes_resource_dsc_resource.rst
@@ -2,4 +2,4 @@
 .. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
 
 
-The |resource dsc_resource| resource allows any |windows powershell_dsc_short| resource to be used in a |chef| recipe, as well as any `custom resources <http://technet.microsoft.com/en-us/library/dn249921.aspx>`_ that have been added to your |windows powershell| environment. |microsoft| `frequently adds new resources <http://gallery.technet.microsoft.com/scriptcenter/DSC-Resource-Kit-All-c449312d>`_ to the |windows powershell_dsc_short| resource collection.
+The |resource dsc_resource| resource allows any |windows powershell_dsc_short| resource to be used in a |chef| recipe, as well as any `custom resources <http://technet.microsoft.com/en-us/library/dn249921.aspx>`_ that have been added to your |windows powershell| environment. |microsoft| `frequently adds new resources <http://github.com/powershell/DscResources>`_ to the |windows powershell_dsc_short| resource collection.


### PR DESCRIPTION
The TechNet version of the DSC Resource Kit is no longer updated. All active development is now being done on GitHub.
