### PR TITLE
FIX to the user resource documentation

### DIFF
--- a/chef_master/source/resource_user.rst
+++ b/chef_master/source/resource_user.rst
@@ -36,7 +36,7 @@ Examples
 =====================================================
 |generic resource statement|
 
-**Create a random user**
+**Create a user named 'random'**
 
 .. include:: ../../step_resource/step_resource_user_create_random.rst
 

--- a/step_resource/step_resource_user_create_random.rst
+++ b/step_resource/step_resource_user_create_random.rst
@@ -1,4 +1,4 @@
-.. This is an included how-to. 
+.. This is an included how-to.
 
 .. To create a random user:
 

--- a/step_resource/step_resource_user_create_system_user_with_variable.rst
+++ b/step_resource/step_resource_user_create_system_user_with_variable.rst
@@ -6,8 +6,8 @@ The following example shows how to create a system user. In this instance, the h
 
    user_home = "/home/#{node['cookbook_name']['user']}"
 
-   user node['matching_node']['user'] do
-     gid node['matching_node']['group']
+   user node['cookbook_name']['user'] do
+     gid node['cookbook_name']['group']
      shell '/bin/bash'
      home user_home
      system true

--- a/step_resource/step_resource_user_create_system_user_with_variable.rst
+++ b/step_resource/step_resource_user_create_system_user_with_variable.rst
@@ -1,29 +1,15 @@
-.. This is an included how-to. 
+.. This is an included how-to.
 
-The following example shows how to create a system user using a variable called ``user_home`` where the matching nodes have a group identifier that is the same as the node, and the login shell is ``/bin/bash``:
-
-.. code-block:: ruby
-
-   user_home = "/#{node[:matching_node][:user]}"
-   
-   user 'node[:matching_node][:group]' do
-     gid node[:matching_node][:group]
-     shell '/bin/bash'
-     home 'user_home'
-     system true
-     action :create
-   end
-
-where ``matching_node`` represents a type of node. For example, if the ``user_home`` variable specified ``{node[:nginx]...}``, a recipe might look something like this:
+The following example shows how to create a system user. In this instance, the home value is calculated and stored in a variable called ``user_home`` that is used to set the user's attribute for home.
 
 .. code-block:: ruby
 
-   user_home = "/#{node[:nginx][:user]}"
-   
-   user 'node[:nginx][:group]' do
-     gid node[:nginx][:group]
+   user_home = "/home/#{node['cookbook_name']['user']}"
+
+   user node['matching_node']['user'] do
+     gid node['matching_node']['group']
      shell '/bin/bash'
-     home 'user_home'
+     home user_home
      system true
      action :create
    end


### PR DESCRIPTION
The statement 'create a random user' makes me think this would generate a user at random. This in fact is a user named 'random' that is being created.

The other example of creating a system user with a variable had a number of issues with the syntax. A node variable cannot be used in a single-quoted string like that. Also it does not make sense to create a user with the value of the group attribute. The `user_home` was not creating a directory for home when it probably should be building a path with the user name. The use of the variable `user_hame` also cannot be used with single-quotes around it. Ruby treats that as a the string literally containing the value 'user_home'.
