### PR TITLE
Interpreter attribute not supported for powershell_script and batch resources

### DIFF
--- a/includes_resources/includes_resource_batch_attributes.rst
+++ b/includes_resources/includes_resource_batch_attributes.rst
@@ -48,7 +48,9 @@ This resource has the following properties:
    * - ``interpreter``
      - **Ruby Type:** String
 
-       |interpreter| |interpreter|
+       |interpreter|
+
+       Changing the interpreter property is not supported.
    * - ``notifies``
      - **Ruby Type:** Symbol, 'Chef::Resource[String]', Symbol
 

--- a/includes_resources/includes_resource_powershell_script_attributes.rst
+++ b/includes_resources/includes_resource_powershell_script_attributes.rst
@@ -59,6 +59,8 @@ This resource has the following properties:
      - **Ruby Type:** String
 
        |interpreter|
+
+       Changing the interpreter property is not supported.
    * - ``notifies``
      - **Ruby Type:** Symbol, 'Chef::Resource[String]', Symbol
 


### PR DESCRIPTION
Updated the interpreter property for powershell_script and batch resources.  
We don't support changing the interpreter, as by definition, these resources are designed to be interpreted by powershell.exe and cmd.exe respectively.

@jamescott @btm 
