### PR TITLE
Fix delivery docs around LDAP and GitHub integrations

### DIFF
--- a/includes_delivery/includes_delivery_cli_install_rhel.rst
+++ b/includes_delivery/includes_delivery_cli_install_rhel.rst
@@ -6,10 +6,10 @@ For |redhat enterprise linux| 6.5 and |suse els| 6.5, run the following commands
 
 .. code-block:: bash
 
-   $ curl -o delivery-cli.rpm https://s3.amazonaws.com/delivery-packages/cli/delivery-cli-20150408004719-1.x86_64.rpm
+   $ curl https://packagecloud.io/install/repositories/chef/current/script.rpm.sh | sudo bash
 
 and then:
 
 .. code-block:: bash
 
-   sudo yum install delivery-cli.rpm
+   sudo yum install delivery-cli

--- a/includes_delivery/includes_delivery_github_setup_enterprise_oauth.rst
+++ b/includes_delivery/includes_delivery_github_setup_enterprise_oauth.rst
@@ -3,7 +3,7 @@
 
 You may integrate |chef delivery| and |github| Enterprise or GitHub.com. If you do this, you will be able to use |github| as a **Source Code Provider** when creating a project. Additionally, when adding users to |chef delivery|, to integrate them to a |github| project, you must first have the |chef delivery| |github| integration complete.
 
-.. note:: This procedure is for |chef delivery| deployments that will use |github enterprise| or GitHub.com as the source control manager. |chef delivery| also comes with default Git capabilities that do not require the GitHub OAuth application. For information on onboarding users for the default Git, see :ref:`delivery_default_git`.  
+.. note:: This procedure is for |chef delivery| deployments that will use |github enterprise| or GitHub.com as the source control manager. |chef delivery| also comes with default Git capabilities that do not require the GitHub OAuth application. For information on onboarding users for the default Git, see :ref:`delivery_default_git`.
 
 This guide assumes you have successfully set up the following:
 
@@ -53,7 +53,7 @@ To add the |github| OAuth app to |chef delivery|, log in to the |chef delivery| 
 
 Request Github Token
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
-Log in to the |chef delivery| server and run the following command:
+Log in to the |chef delivery| server and run the following command.  Follow the URL given to finish authorizing |chef delivery| to |github|:
 
 **For Github Enterprise**
 
@@ -70,10 +70,10 @@ Log in to the |chef delivery| server and run the following command:
 Create a Project
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 Before you begin you will need an existing |github| repo with at least one commit and also you have to grant
-admin rights to the ``chef-delivery`` account.
+admin rights to the |chef delivery| account connected to |github|.
 
 #. Open your organization page in the |chef delivery| web UI and create a new project as normal.
-#. Next, select the **Github** option from the bar and enter the **Github Repo Owner**, **Github Repo Name**, and the branch you wish to use as your primary pipeline.
+#. Next, select the **Github** option from the bar and enter the **Github Organization/Owner**, **Github Repo Name**, and the branch you wish to use as your primary pipeline.
 #. Click **Save & Close**.
 
 There is currently no process for migrating an existing |chef delivery| project to one that is backed by |github|.
@@ -145,4 +145,3 @@ Next, push the code to |github|.
 (The |chef delivery_cli| CLI can perform all of this for projects that use local repositories; one day, it'll do it for remote repositories as well.)
 
 Finally, create a pull request from this change in the |github| web UI.
-

--- a/includes_delivery/includes_delivery_users_ldap_attributes.rst
+++ b/includes_delivery/includes_delivery_users_ldap_attributes.rst
@@ -11,22 +11,22 @@ The following table describes the LDAP attributes that may be used with |chef de
    * - Setting
      - Description
    * - ``ldap_attr_fullname``
-     - Use to specify the full user name for an |ldap| user. Default value: ``nil``.     
+     - Field from |ldap| to populate the full name for an |ldap| user. Default value: ``nil``.
    * - ``ldap_attr_login``
-     - Use to specify the login user name for an |ldap| user. Default value: ``nil``.
+     - Field from |ldap| to use as login user name for an |ldap| user. Default value: ``sAMAccountName``.
    * - ``ldap_attr_mail``
-     - Use to specify the email for an |ldap| user. Default value: ``OU=Employees,OU=Domain users,DC=examplecorp,DC=com``.
+     - Field from |ldap| to populate the email for an |ldap| user. Default value: ``mail``.
    * - ``ldap_base_dn``
-     - This is typically ``cn=users`` and then the domain. Default value: ``ldapbind``.
+     - Base dn to use when searching for users in |ldap|, typically ``OU=Users`` and then the domain. Default value: ``OU=Employees,OU=Domain users,DC=examplecorp,DC=com``.
    * - ``ldap_bind_dn``
      - The user |chef delivery| will use to perform |ldap| searches. This is often the administrator or manager user. This user needs to have read access to all |ldap| users that require authentication. The |chef delivery| server must do an |ldap| search before any user can log in. Many |ldap| systems do not allow an anonymous bind. If anonymous bind is allowed, leave the ``bind_dn`` and ``bind_dn_password`` settings blank. If anonymous bind is not allowed, a user with ``READ`` access to the directory is required. This user must be specified as an |ldap| distinguished name (``dn``). Default value: ``nil``.
    * - ``ldap_bind_dn_password``
      - The password for the user specified by ``ldap['bind_dn']``. Leave this value and ``ldap['bind_dn']`` unset if anonymous bind is sufficient. Default value: ``secret123``.
    * - ``ldap_encryption``
-     - The type of encryption used to communicate with |chef delivery|. Default value: ``start_tls``.
-   * - ``ldap_host``
-     - The hostname of the |ldap| server. Be sure |chef delivery| is able to resolve any host names. Default value: ``ldap-server-host``.
+     - The type of encryption used to communicate with |chef delivery|. Default value: ``start_tls``.  If tls is not in use, set to ``no_tls``
+   * - ``ldap_hosts``
+     - An array of hostname(s) of the |ldap| server. Be sure |chef delivery| is able to resolve any host names. Default value: ``[]``.
    * - ``ldap_port``
      - The default value is an appropriate value for most configurations. Default value: ``3269``.
    * - ``ldap_timeout``
-     - Default value: ``5000``.
+     - Timeout when |chef delivery| connects to |ldap|. Default value: ``5000``.

--- a/includes_delivery/includes_delivery_users_ldap_configure.rst
+++ b/includes_delivery/includes_delivery_users_ldap_configure.rst
@@ -4,14 +4,22 @@
 
 To configure LDAP for |chef delivery|:
 
-#. From your ``delivery-cluster`` repo on your provisioning node, modify the ``environments/.json`` file as follows with the LDAP attributes you want |chef delivery| to use. If you do not specify an LDAP port, the default port of ``3269`` is used. 
+#. From your ``delivery-cluster`` repo on your provisioning node, modify the ``environments/.json`` file as follows with the LDAP attributes you want |chef delivery| to use. If you do not specify an LDAP port, the default port of ``3269`` is used.
 
    .. code-block:: javascript
 
       "delivery": {
         "ldap": {
-            "OPTION1": "VALUE1",
-            "OPTION2": "VALUE2"
+            "ldap_attr_login": "sAMAccountName"
+            "ldap_attr_mail": "mail",
+            "ldap_attr_full_name": "fullName"
+            "ldap_base_dn": "OU=Employees,OU=Domain users,DC=opscodecorp,DC=com",
+            "ldap_bind_dn": "ldapbind",
+            "ldap_bind_dn_password": "secret123",
+            "ldap_encryption": "start_tls",
+            "ldap_hosts": "[ldap.tld]",
+            "ldap_port": 3269,
+            "ldap_timeout": 5000,
         }
       }
 

--- a/includes_delivery/includes_delivery_users_ldap_user_add.rst
+++ b/includes_delivery/includes_delivery_users_ldap_user_add.rst
@@ -9,26 +9,22 @@ To add or edit a user to |chef delivery|:
 #. Select **Users** from the drop-down menu on the upper right.
 
    The **Users** list page opens. You can use the search filter in the upper right corner to make sure that the user is not already added.
-#. Click the plus sign (**+**) next to **Add a New User**.  
+#. Click the plus sign (**+**) next to **Add a New User**.
 #. In the Add New a User text area, select one of two types for the new user. The selection box is grey for the active selection.
 
-   * **Internal** means you are manually adding the user to the |chef delivery| database. 
+   * **Internal** means you are manually adding the user to the |chef delivery| database.
 
-   * **LDAP** means the user is in an LDAP system that has been integrated to this |chef delivery|. 
+   * **LDAP** means the user is in an LDAP system that has been integrated to this |chef delivery|.
 
    If you select **Internal**, options for **Name and Email**, first name, last name, email address, and **Security Information**, a login name and password, appear.
-   
+
    If you select **LDAP**, the **Name and Email** options go away and a **Security Information** option for the user's LDAP username and SSH public key appears.
 #. Enter the appropriate information for the type of user you are adding. Leave the **SSH Public Key**  area blank, the user must log in and enter this information.
 
-   Select user **Roles Within the Enterprise**. For details, see :ref: `roles_permissions`.
+   Select user **Roles Within the Enterprise**. For details, see :ref:`roles_permissions`.
 
    Click **Save and Close**, or **Cancel** to discard the operation.
-   
+
    The **User** list page opens and a status message appears.
 
 To check that the user was added properly when using LDAP, click **Edit** and verify that the user details are present.
-
-
-
-

--- a/includes_delivery/includes_delivery_users_onboard_github_add.rst
+++ b/includes_delivery/includes_delivery_users_onboard_github_add.rst
@@ -7,8 +7,8 @@ To onboard a user for an integrated |github enterprise| or GitHub.com project:
 #. Follow the instructions in :ref:`add_users_default`.
 #. From a local checkout of a |chef delivery| project, run the appropriate |chef delivery| command that associates a |github| user with a |chef delivery| user.
 
-   .. note:: The |chef delivery_cli| commands can be run from a user's workstation and only affect themselves, or others if the user has the **Admin** role; ``api`` is an argument to the |chef delivery_cli| CLI command. The ``delivery-ctl`` command can only be run by an administrator from the |chef delivery| server and can affect any user.
-   
+   .. note:: The |chef delivery_cli| commands are for a user to link their own account to |github|, or others if the user has the **Admin** role; ``api`` is an argument to the |chef delivery_cli| CLI command. The ``delivery-ctl`` command can only be run by an administrator from the |chef delivery| server and can affect any user.
+
    For |github enterprise|:
 
    .. code-block:: bash
@@ -21,16 +21,23 @@ To onboard a user for an integrated |github enterprise| or GitHub.com project:
 
       $ delivery api put users/$DELIVERY_USERNAME/set-oauth-alias --data='{"app_name":"github","alias":"$GITHUB_USERNAME"}'
 
-   Then run ``delivery-ctl``. The command uses the enterprise name set when configuring |chef delivery|. The username can be an LDAP username (if LDAP integration has been completed), or an internal username:
+   Or as an administrator run ``delivery-ctl``. The command uses the enterprise name set when configuring |chef delivery|. The username can be an LDAP username (if LDAP integration has been completed), or an internal username:
+
+   For |github enterprise|:
+
+   .. code-block:: bash
+
+      $ delivery-ctl link-github-enterprise-user $DELIVERY_ENTERPRISE_NAME $DELIVERY_USERNAME $GITHUB_USERNAME
+
+   For |github|:
 
    .. code-block:: bash
 
       $ delivery-ctl link-github-user $DELIVERY_ENTERPRISE_NAME $DELIVERY_USERNAME $GITHUB_USERNAME
 
-The associated user can now checkout the repository, make changes on a feature branch and submit the changes for review. 
+The associated user can now checkout the repository, make changes on a feature branch and submit the changes for review.
 
 Note the following constraints:
 
 * You may not link two |github| accounts to a single |chef delivery| user.
 * Two users may not share a |github| account
-


### PR DESCRIPTION
While working on-site with a customer today, found a few areas of the documentation incomplete or lacking context.
- Updated the LDAP attributes section to fix `ldap_host` to `ldap_hosts`
- Updated the LDAP attributes section to clarify the use of various attributes
- Updated the LDAP attributes example to include a properly formatted JSON with actual examples
- Updated the RHEL delivery-cli install to install via packagecloud yum repo
- Updated the GitHub user linking to be more clear in using delivery-cli or delivery-ctl
- Updated the GitHub Token section to inform you to follow the URL given
