### PR TITLE
Monitor Disks and oos First

### DIFF
--- a/chef_master/source/server_monitor.rst
+++ b/chef_master/source/server_monitor.rst
@@ -4,6 +4,23 @@ Monitor
 
 .. include:: ../../includes_server_monitor/includes_server_monitor.rst
 
+Top Priority Monitoring Focus
+=====================================================
+
+The following items are the top priority for monitoring.
+If you monitor no other aspect of your Chef Server systems,
+these are the two items to track. In our experience,
+running out of disk space is the number one cause of
+Chef Server failure.
+
+Disks
+-----------------------------------------------------
+.. include:: ../../includes_server_monitor/includes_server_monitor_system_disk.rst
+
+HA Specific
+-----------------------------------------------------
+.. include:: ../../includes_server_monitor/includes_server_monitor_system_ha.rst
+
 Application Checks
 =====================================================
 .. include:: ../../includes_server_monitor/includes_server_monitor_application.rst
@@ -74,6 +91,3 @@ Nodes, Workstations
 =====================================================
 .. include:: ../../includes_server_monitor/includes_server_monitor_system_client.rst
 
-Disks
-=====================================================
-.. include:: ../../includes_server_monitor/includes_server_monitor_system_disk.rst

--- a/includes_server_monitor/includes_server_monitor_system_disk.rst
+++ b/includes_server_monitor/includes_server_monitor_system_disk.rst
@@ -4,6 +4,17 @@
 
 Over time, and with enough data, disks will fill up or exceed the per-disk quotas that may have been set for them and they will not be able to write data. A disk that is not able to write data will not be able to support certain components of the |chef server|, such as |postgresql|, |rabbitmq|, service log files, and deleted file handles. Monitoring disk usage is the best way to ensure that disks don't fill up or exceed their quota.
 
+Commands that can be used to monitor global disk usage on a Chef Server with a typical installation
+
+.. code-block:: bash
+
+   $ du -sh /var/opt/opscode 
+   $ du -sh /var/log/opscode 
+
+To stay healthy, neither one of these areas should ever become more than 80% used.
+If disk space begins to grow at a rapid pace, the best option in that case is to shut down and work with Chef
+to identify the cause.
+
 The following components should be monitored for signs that disks may be rapidly filling up:
 
 * **PostgreSQL** |postgresql| is the data store for the |chef server|.

--- a/includes_server_monitor/includes_server_monitor_system_ha.rst
+++ b/includes_server_monitor/includes_server_monitor_system_ha.rst
@@ -1,4 +1,29 @@
 .. The contents of this file are included in multiple topics.
 .. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
 
-Within the back-end, the ha-status endpoint provides important information about the health of the high availability pair. If any checks return the ``[ERROR]`` status, this indicates that the cluster is in the middle of a failover, is misconfigured, or is experiencing an error.
+All components of computer systems fail, and ethernet networks, while being generally very robust, are no exception.
+Chef Server DRBD HA depends on a functioning network to begin and maintain replication between the two backend
+members of a Chef Server HA cluster.
+
+To become aware of failure at the earliest opportunity, the /proc/drbd psuedo file should be monitored for signs
+that the cluster replication has stopped or is falling behind:
+
+A healthy output looks like this
+
+.. code-block:: bash
+
+   $ cat /proc/drbd
+   version: 8.4.0 (api:1/proto:86-100)
+   GIT-hash: 09b6d528b3b3de50462cd7831c0a3791abc665c3 build by linbit@buildsystem.linbit, 2011-10-12 09:07:35
+    0: cs:Connected ro:Secondary/Secondary ds:UpToDate/UpToDate C r-----
+       ns:0 nr:0 dw:0 dr:656 al:0 bm:0 lo:0 pe:0 ua:0 ap:0 ep:1 wo:b oos:0
+
+An unhealthy connection can look like this from the perspective of the initial Primary, where we have lost communication with the Secondary and oos, Out Of Sync is non-zero and increasing. This is not fatal, but represents a degraded mode for the cluster. It means we are no longer in sync to within a few milliseconds, but are building up a queue of unwritten writes on the originating side that must be eventually synchronized to the Secondary when the network connection once again becomes usable.
+
+.. code-block:: bash
+
+   $ cat /proc/drbd
+   version: 8.4.0 (api:1/proto:86-100)
+   GIT-hash: 09b6d528b3b3de50462cd7831c0a3791abc665c3 build by linbit@buildsystem.linbit, 2011-10-12 09:07:35
+    0: cs:WFConnection ro:Primary/Secondary ds:UpToDate/Unknown C r---
+       ns:0 nr:0 dw:0 dr:0 al:0 bm:0 lo:0 pe:0 ua:0 ap:0 ep:1 wo:b oos:54192


### PR DESCRIPTION
We should monitor disks and Out Of Sync first, if nothing else.
All other monitoring would be nice to have. Many Support tickets are generated by out of disk conditions, so it makes the most sense to start there. Rearrange server monitoring page to point out that disk space free and HA replication are the top priority.
