### PR TITLE
Move styles from css file to scss files

### DIFF
--- a/_themes/chefv2/static/chefv2.css_t
+++ b/_themes/chefv2/static/chefv2.css_t
@@ -238,7 +238,7 @@ p {
   margin: 0 0 0.5em 0; }
 
 .documentwrapper img {
-  margin: 0.5em 0.5em 0.5em 0.5em; }
+  margin: 0.5em; }
 
 a {
   color: #6bb2e2;

--- a/_themes/chefv2/static/chefv2.css_t
+++ b/_themes/chefv2/static/chefv2.css_t
@@ -237,7 +237,7 @@ div.footer a:hover {
 p {
   margin: 0 0 0.5em 0; }
 
-img {
+.documentwrapper img {
   margin: 0.5em 0.5em 0.5em 0.5em; }
 
 a {
@@ -266,7 +266,6 @@ em {
 
 /* -- header styles, basically Opscode blue with colored underlines and decreasing border bottom sizes */
 .chef-docs h1 {
-  margin: 0.5;
   padding: 0.5em 0 0.3em 0;
   font-size: 1.75em;
   font-weight: bold;
@@ -275,7 +274,6 @@ em {
   margin: 0 0 0.5em 0; }
 
 .chef-docs h2 {
-  margin: 0.5em 0 0.2em 0;
   font-size: 1.55em;
   font-weight: bold;
   color: #3f5364;
@@ -284,7 +282,6 @@ em {
   margin: 0 0 0.5em 0; }
 
 .chef-docs h3 {
-  margin: 0.5em 0 -0.3em 0;
   font-size: 1.35em;
   font-weight: bold;
   color: #3f5364;
@@ -293,22 +290,20 @@ em {
   margin: 0 0 0.5em 0; }
 
 .chef-docs h4 {
-  margin: 0.5em 0 -0.3em 0;
+  margin: 0 0 0.5em 0;
+  font-size: 1.35em;
+  font-weight: bold;
+  color: #3f5364;
+  padding: 0.7em 0 0.3em 0;
+  border-bottom: solid 0px #7d868c; }
+
+.chef-docs h5 {
   font-size: 1.35em;
   font-weight: bold;
   color: #3f5364;
   padding: 0.7em 0 0.3em 0;
   border-bottom: solid 0px #7d868c;
   margin: 0 0 0.5em 0; }
-
-  .chef-docs h5 {
-    margin: 0.5em 0 -0.3em 0;
-    font-size: 1.35em;
-    font-weight: bold;
-    color: #3f5364;
-    padding: 0.7em 0 0.3em 0;
-    border-bottom: solid 0px #7d868c;
-    margin: 0 0 0.5em 0; }
 
 div.body h1 a, div.body h2 a, div.body h3 a, div.body h4 a, div.body h5 a, div.body h6 a {
   color: #ffffff !important; }

--- a/_themes/chefv2/static/scss/_sphinx.scss
+++ b/_themes/chefv2/static/scss/_sphinx.scss
@@ -200,7 +200,7 @@ p {
 }
 
 .documentwrapper img {
-  margin: 0.5em 0.5em 0.5em 0.5em;
+  margin: 0.5em;
 }
 
 a {

--- a/_themes/chefv2/static/scss/_sphinx.scss
+++ b/_themes/chefv2/static/scss/_sphinx.scss
@@ -195,13 +195,16 @@ div.footer a:hover {
 
 /* -- body styles ----------------------------------------------------------- */
 
-p {    
-    margin: 0.8em 0 0.5em 0;
+p {
+    margin: 0 0 0.5em 0;
 }
 
+.documentwrapper img {
+  margin: 0.5em 0.5em 0.5em 0.5em;
+}
 
-a { 
-    color: #6bb2e2; 
+a {
+    color: #6bb2e2;
     text-decoration: none;
 }
 
@@ -234,38 +237,48 @@ em {
 /* -- header styles, basically Opscode blue with colored underlines and decreasing border bottom sizes */
 
 .chef-docs h1 {
-    margin: 0.5;
     padding: 0.5em 0 0.3em 0;
     font-size: 1.75em;
     font-weight: bold;
     color: #3f5364;
-    border-bottom:solid 4px #f18b21;
+    border-bottom: solid 4px #f18b21;
+    margin: 0 0 0.5em 0;
 }
 
 .chef-docs h2 {
-    margin: 0.5em 0 0.2em 0;
     font-size: 1.55em;
     font-weight: bold;
     color: #3f5364;
     padding: 0.7em 0 0.3em 0;
-    border-bottom:solid 2px #7d868c;
+    border-bottom: solid 2px #7d868c;
+    margin: 0 0 0.5em 0;
 }
 
 .chef-docs h3 {
-    margin: 0.5em 0 -0.3em 0;
     font-size: 1.35em;
     font-weight: bold;
     color: #3f5364;
     padding: 0.7em 0 0.3em 0;
     border-bottom:solid 1px #7d868c;
+    margin: 0 0 0.5em 0;
 }
 
 .chef-docs h4 {
-    margin: 0.5em 0 -0.3em 0;
+    margin: 0 0 0.5em 0;
     font-size: 1.35em;
+    font-weight: bold;
     color: #3f5364;
     padding: 0.7em 0 0.3em 0;
     border-bottom:solid 0px #7d868c;
+}
+
+.chef-docs h5 {
+    font-size: 1.35em;
+    font-weight: bold;
+    color: #3f5364;
+    padding: 0.7em 0 0.3em 0;
+    border-bottom: solid 0px #7d868c;
+    margin: 0 0 0.5em 0;
 }
 
 div.body h1 a, div.body h2 a, div.body h3 a, div.body h4 a, div.body h5 a, div.body h6 a {
@@ -357,6 +370,7 @@ pre {
     border: 0.0px solid #d8dde3;
     background-color: #ebecf1;
     overflow-x: scroll;
+    margin: 0 0 0.5em 0;
 }
 
 pre a {
@@ -395,7 +409,7 @@ table.docutils {
     border: 0;
     border-collapse: separate;
     border-spacing:4px;
-
+    margin: 0 0 0.5em 0;
 }
 
 table.docutils tr {


### PR DESCRIPTION
To prevent styles being overridden by accident, all styles should
be written to scss files and then compiled to the chefv2.css_t
file. This moves a few styles that were added directly to the css
file into the _sphinx.scss file.
