### PR TITLE
ruby "environments" are not available in local mode

### DIFF
--- a/includes_environment/includes_environment_format.rst
+++ b/includes_environment/includes_environment_format.rst
@@ -1,4 +1,8 @@
 .. The contents of this file are included in multiple topics.
 .. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
 
-Environment data may be stored in two formats: as |ruby| (i.e. a file that ends with ``.rb``) or as |json| (i.e. a file that ends with ``.json``).
+Environment data may be stored in two formats: 
+
+* as |ruby|, i.e. a file that ends with ``.rb`` 
+  (if you are using |chef client| in local mode, this option is not available: use the |json| format)
+* as |json|, i.e. a file that ends with ``.json``


### PR DESCRIPTION
I had to search quite a bit to find out that the environments may not use the ruby format when using chef-client in local mode (chef zero)
