### PR TITLE
Update includes_inspec_resource_command_matcher_stdout.rst

### DIFF
--- a/includes_inspec_resources/includes_inspec_resource_command_matcher_stdout.rst
+++ b/includes_inspec_resources/includes_inspec_resource_command_matcher_stdout.rst
@@ -2,7 +2,11 @@
 .. This file should not be changed in a way that hinders its ability to appear in multiple documentation sets.
 
 The ``stdout`` matcher tests results of the command as returned in standard output (stdout):
+In this example it is matching the output (stdout) using a RegEx
 
 .. code-block:: ruby
 
-   its('stdout') { should eq '/^1$/' }
+   describe command('echo 1') do
+      its('stdout') { should match (/[0-9]/) }
+   end
+   


### PR DESCRIPTION
The previous example its('stdout') { should eq '/^1$/' } doesn't work, in that it does not evaluate stdout using regex.
I’ve changed this to show a working RegEx example.
