### PR TITLE
We have http://localhost:4000 in the API docs

### DIFF
--- a/includes_api_chef_server/includes_api_chef_server_endpoint_cookbook_name_get.rst
+++ b/includes_api_chef_server/includes_api_chef_server_endpoint_cookbook_name_get.rst
@@ -28,11 +28,11 @@ The response is similar to:
 
    {
      "apache2" => {
-       "url" => "http://localhost:4000/cookbooks/apache2",
+       "url" => "https://localhost/cookbooks/apache2",
        "versions" => [
-         {"url" => "http://localhost:4000/cookbooks/apache2/5.1.0",
+         {"url" => "https://localhost/cookbooks/apache2/5.1.0",
           "version" => "5.1.0"},
-         {"url" => "http://localhost:4000/cookbooks/apache2/4.2.0",
+         {"url" => "https://localhost/cookbooks/apache2/4.2.0",
           "version" => "4.2.0"}
        ]
      }

--- a/includes_api_chef_server/includes_api_chef_server_endpoint_cookbooks_get.rst
+++ b/includes_api_chef_server/includes_api_chef_server_endpoint_cookbooks_get.rst
@@ -29,20 +29,20 @@ The response is similar to:
 
    {
      "apache2" => {
-       "url" => "http://localhost:4000/cookbooks/apache2",
+       "url" => "https://localhost/cookbooks/apache2",
        "versions" => [
-         {"url" => "http://localhost:4000/cookbooks/apache2/5.1.0",
+         {"url" => "https://localhost/cookbooks/apache2/5.1.0",
           "version" => "5.1.0"},
-         {"url" => "http://localhost:4000/cookbooks/apache2/4.2.0",
+         {"url" => "https://localhost/cookbooks/apache2/4.2.0",
           "version" => "4.2.0"}
        ]
      },
      "nginx" => {
-       "url" => "http://localhost:4000/cookbooks/nginx",
+       "url" => "https://localhost/cookbooks/nginx",
        "versions" => [
-         {"url" => "http://localhost:4000/cookbooks/nginx/1.0.0",
+         {"url" => "https://localhost/cookbooks/nginx/1.0.0",
           "version" => "1.0.0"},
-         {"url" => "http://localhost:4000/cookbooks/nginx/0.3.0",
+         {"url" => "https://localhost/cookbooks/nginx/0.3.0",
           "version" => "0.3.0"}
        ]
      }

--- a/includes_api_chef_server/includes_api_chef_server_endpoint_cookbooks_latest_get.rst
+++ b/includes_api_chef_server/includes_api_chef_server_endpoint_cookbooks_latest_get.rst
@@ -18,8 +18,8 @@ For example, if cookbooks ``foo`` and ``bar`` both exist on the |chef server| an
 .. code-block:: javascript
 
   {
-    "foo": "http://localhost:4000/cookbooks/foo/0.2.0",
-    "bar": "http://localhost:4000/cookbooks/bar/0.2.0"
+    "foo": "https://localhost/cookbooks/foo/0.2.0",
+    "bar": "https://localhost/cookbooks/bar/0.2.0"
   }
 
 **Response Codes**

--- a/includes_api_chef_server/includes_api_chef_server_endpoint_data_bag_name_get.rst
+++ b/includes_api_chef_server/includes_api_chef_server_endpoint_data_bag_name_get.rst
@@ -18,7 +18,7 @@ The response is similar to:
 .. code-block:: javascript
 
    {
-      "adam": "http://localhost:4000/data/users/adam"
+      "adam": "https://localhost/data/users/adam"
    }
 
 **Response Codes**

--- a/includes_api_chef_server/includes_api_chef_server_endpoint_data_bags_get.rst
+++ b/includes_api_chef_server/includes_api_chef_server_endpoint_data_bags_get.rst
@@ -18,11 +18,11 @@ The response is similar to:
 .. code-block:: javascript
 
    {
-     "users": "http://localhost:4000/data/users",
-     "applications": "http://localhost:4000/data/applications"
+     "users": "https://localhost/data/users",
+     "applications": "https://localhost/data/applications"
    }
 
-shown as a list of key-value pairs, where (in the example above) ``users`` and ``applications`` are the names of data bags and "http://localhost:4000/data/foo" is the path to the data bag.
+shown as a list of key-value pairs, where (in the example above) ``users`` and ``applications`` are the names of data bags and "https://localhost/data/foo" is the path to the data bag.
 
 **Response Codes**
 

--- a/includes_api_chef_server/includes_api_chef_server_endpoint_environment_cookbook_name_get.rst
+++ b/includes_api_chef_server/includes_api_chef_server_endpoint_environment_cookbook_name_get.rst
@@ -30,11 +30,11 @@ The response is similar to:
 
    {
      "apache2" => {
-       "url" => "http://localhost:4000/cookbooks/apache2",
+       "url" => "https://localhost/cookbooks/apache2",
        "versions" => [
-         {"url" => "http://localhost:4000/cookbooks/apache2/5.1.0",
+         {"url" => "https://localhost/cookbooks/apache2/5.1.0",
           "version" => "5.1.0"},
-         {"url" => "http://localhost:4000/cookbooks/apache2/4.2.0",
+         {"url" => "https://localhost/cookbooks/apache2/4.2.0",
           "version" => "4.2.0"}
        ]
      }

--- a/includes_api_chef_server/includes_api_chef_server_endpoint_environment_cookbooks_get.rst
+++ b/includes_api_chef_server/includes_api_chef_server_endpoint_environment_cookbooks_get.rst
@@ -28,20 +28,20 @@ The response is similar to:
 
    {
      "apache2" => {
-       "url" => "http://localhost:4000/cookbooks/apache2",
+       "url" => "https://localhost/cookbooks/apache2",
        "versions" => [
-         {"url" => "http://localhost:4000/cookbooks/apache2/5.1.0",
+         {"url" => "https://localhost/cookbooks/apache2/5.1.0",
           "version" => "5.1.0"},
-         {"url" => "http://localhost:4000/cookbooks/apache2/4.2.0",
+         {"url" => "https://localhost/cookbooks/apache2/4.2.0",
           "version" => "4.2.0"}
        ]
      },
      "nginx" => {
-       "url" => "http://localhost:4000/cookbooks/nginx",
+       "url" => "https://localhost/cookbooks/nginx",
        "versions" => [
-         {"url" => "http://localhost:4000/cookbooks/nginx/1.0.0",
+         {"url" => "https://localhost/cookbooks/nginx/1.0.0",
           "version" => "1.0.0"},
-         {"url" => "http://localhost:4000/cookbooks/nginx/0.3.0",
+         {"url" => "https://localhost/cookbooks/nginx/0.3.0",
           "version" => "0.3.0"}
        ]
      }

--- a/includes_api_chef_server/includes_api_chef_server_endpoint_environments_post.rst
+++ b/includes_api_chef_server/includes_api_chef_server_endpoint_environments_post.rst
@@ -30,7 +30,7 @@ The response is similar to:
 
 .. code-block:: javascript
 
-   { "uri": "http://localhost:4000/environments/dev" }
+   { "uri": "https://localhost/environments/dev" }
 
 **Response Codes**
 

--- a/includes_api_chef_server/includes_api_chef_server_endpoint_nodes_get.rst
+++ b/includes_api_chef_server/includes_api_chef_server_endpoint_nodes_get.rst
@@ -18,7 +18,7 @@ The response is similar to:
 .. code-block:: javascript
 
    {
-     "latte": "http://localhost:4000/nodes/latte"
+     "latte": "https://localhost/nodes/latte"
    }
 
 **Response Codes**

--- a/includes_api_chef_server/includes_api_chef_server_endpoint_nodes_post.rst
+++ b/includes_api_chef_server/includes_api_chef_server_endpoint_nodes_post.rst
@@ -35,7 +35,7 @@ The response is similar to:
 
 .. code-block:: javascript
 
-   { "uri": "http://localhost:4000/nodes/latte" }
+   { "uri": "https://localhost/nodes/latte" }
 
 **Response Codes**
 

--- a/includes_api_chef_server/includes_api_chef_server_endpoint_roles_get.rst
+++ b/includes_api_chef_server/includes_api_chef_server_endpoint_roles_get.rst
@@ -18,7 +18,7 @@ The response is similar to:
 .. code-block:: javascript
 
    {
-     "webserver": "http://localhost:4000/roles/webserver"
+     "webserver": "https://localhost/roles/webserver"
    }
 
 **Response Codes**

--- a/includes_api_chef_server/includes_api_chef_server_endpoint_roles_post.rst
+++ b/includes_api_chef_server/includes_api_chef_server_endpoint_roles_post.rst
@@ -34,7 +34,7 @@ The response is similar to:
 
 .. code-block:: javascript
 
-   { "uri": "http://localhost:4000/roles/webserver" }
+   { "uri": "https://localhost/roles/webserver" }
 
 **Response Codes**
 

--- a/includes_api_chef_server/includes_api_chef_server_endpoint_search_get.rst
+++ b/includes_api_chef_server/includes_api_chef_server_endpoint_search_get.rst
@@ -20,10 +20,10 @@ The response is similar to:
 .. code-block:: javascript
 
    {
-     "node": "http://localhost:4000/search/node",
-     "role": "http://localhost:4000/search/role",
-     "client": "http://localhost:4000/search/client",
-     "users": "http://localhost:4000/search/users"
+     "node": "https://localhost/search/node",
+     "role": "https://localhost/search/role",
+     "client": "https://localhost/search/client",
+     "users": "https://localhost/search/users"
    }
 
 **Response Codes**


### PR DESCRIPTION
- This removes the pre-Chef 12 default port from our docs. We strongly suggest not running Chef server on `4000` now and Chef 12 defaults to `https` also. This should be reflected in our docs.
