### PR TITLE
Include rabbitmq management console port (15672) in tiered and ha bac…

### DIFF
--- a/includes_server_firewalls_and_ports/includes_server_firewalls_and_ports_be.rst
+++ b/includes_server_firewalls_and_ports/includes_server_firewalls_and_ports_be.rst
@@ -57,7 +57,7 @@ For back-end servers, ensure that ports marked as external (marked as ``yes`` in
 
        .. include:: ../../includes_server_services/includes_server_services_postgresql.rst
      - yes
-   * - 5672
+   * - 5672, 15672
      - |service rabbitmq|
 
        .. include:: ../../includes_server_services/includes_server_services_rabbitmq.rst

--- a/includes_server_firewalls_and_ports/includes_server_firewalls_and_ports_tiered.rst
+++ b/includes_server_firewalls_and_ports/includes_server_firewalls_and_ports_tiered.rst
@@ -32,7 +32,7 @@ For back-end servers in a tiered |chef server| installation, ensure that ports m
 
        .. include:: ../../includes_server_services/includes_server_services_postgresql.rst
      - 
-   * - 5672
+   * - 5672, 15672
      - |service rabbitmq|
 
        .. include:: ../../includes_server_services/includes_server_services_rabbitmq.rst


### PR DESCRIPTION
…kend port requirements. Frontends need to use this for new queue management features.
