### PR TITLE
Clarify node_name in the context of knife.rb

### DIFF
--- a/includes_config/includes_config_rb_11-16_knife_settings.rst
+++ b/includes_config/includes_config_rb_11-16_knife_settings.rst
@@ -66,11 +66,11 @@ This configuration file has the following settings:
       local_mode true
 
 ``node_name``
-   |name node| This is typically also the same name as the computer from which |knife| is run. For example:
+   |name node| This is the username you are using to connect to the Chef server. This is may also the same name as the computer from which |knife| is run. For example:
 
    .. code-block:: ruby
 
-      node_name 'node_name'
+      node_name 'some_user'
 
 ``no_proxy``
    |no_proxy| Default value: ``nil``. For example:


### PR DESCRIPTION
In the knife.rb configuration file, node_name actually configures the username that's used to authenticate to the chef server. The current documentation is a little misleading about this.
