### PR TITLE
Add mdadm_defaults attribute on the mdadm resource to documentation

### DIFF
--- a/includes_resources/includes_resource_mdadm_attributes.rst
+++ b/includes_resources/includes_resource_mdadm_attributes.rst
@@ -2,7 +2,12 @@
 .. The contents of this file should be modified in a way that preserves its ability to appear in multiple topics.
 
 This resource has the following properties:
-   
+
+``mdadm_defaults``
+   **Ruby Types:** TrueClass, FalseClass
+
+   |mdadm_defaults| Default value: ``false``.  
+
 ``bitmap``
    **Ruby Type:** String
 

--- a/includes_resources/includes_resource_mdadm_syntax.rst
+++ b/includes_resources/includes_resource_mdadm_syntax.rst
@@ -17,6 +17,7 @@ The full syntax for all of the properties that are available to the |resource md
 .. code-block:: ruby
 
    mdadm 'name' do
+     mdadm_defaults             TrueClass, FalseClass
      bitmap                     String
      chunk                      Integer
      devices                    Array
@@ -35,4 +36,4 @@ where
 * ``mdadm`` is the resource
 * ``name`` is the name of the resource block
 * ``:action`` identifies the steps the |chef client| will take to bring the node into the desired state
-* ``bitmap``, ``chunk``, ``devices``, ``exists``, ``level``, ``metadata``, ``provider``,  and ``raid_device`` are properties of this resource, with the |ruby| type shown. |see attributes|
+* ``mdadm_defaults``, ``bitmap``, ``chunk``, ``devices``, ``exists``, ``level``, ``metadata``, ``provider``,  and ``raid_device`` are properties of this resource, with the |ruby| type shown. |see attributes|

--- a/swaps/swap_descriptions.txt
+++ b/swaps/swap_descriptions.txt
@@ -781,6 +781,7 @@
 .. |max_retry| replace:: The maximum number of attempts made to retrieve a file before returning an error.
 .. |maximum_transmission_unit| replace:: The maximum transmission unit (MTU) for the network interface.
 .. |md5_auth_cidr_addresses| replace:: Use instead of ``trust_auth_cidr_addresses`` to encrypt passwords using MD5 hashes.
+.. |mdadm_defaults| replace:: When true this property sets the default values for ``chunk`` and ``metadata`` to ``nil`` allowing mdadm to use it's own default values.
 .. |mdpolicy| replace:: The metadata download policy for the repository metadata index.
 .. |media location| replace:: The geographic location for a virtual machine and its services.
 .. |medium| replace:: Display normal attributes in the output and to show the output as |json|.


### PR DESCRIPTION
This supports the changes made in the following PR
- https://github.com/chef/chef/pull/2915

I wasn't sure how to make these change so that they only show up in the documentation starting with the version that includes this change.
