### PR TITLE
Update push jobs workstation install instructions

### DIFF
--- a/includes_install/includes_install_push_jobs_workstation.rst
+++ b/includes_install/includes_install_push_jobs_workstation.rst
@@ -7,4 +7,4 @@ To set up the |push jobs| workstation, install the |subcommand knife push jobs| 
 
    chef gem install knife-push
 
-Once installed, the following subcommands will be available: ``knife node status``, ``knife job list``, ``knife job start``, and ``knife job status``. 
+Once installed, the following subcommands will be available: ``knife job status``, ``knife job list``, ``knife job start``, and ``knife job status``. 


### PR DESCRIPTION
Changes `node` to `job`.
