### PR TITLE
removes supports[:manage_home] and supports[:non_unique]

### DIFF
--- a/chef_master/source/resource_user.rst
+++ b/chef_master/source/resource_user.rst
@@ -16,10 +16,6 @@ Properties
 =====================================================
 .. include:: ../../includes_resources/includes_resource_user_attributes.rst
 
-Supported Features
-=====================================================
-.. include:: ../../includes_resources/includes_resource_user_supported_features.rst
-
 Password Shadow Hash
 =====================================================
 .. include:: ../../includes_resources/includes_resource_user_password_shadow_hash.rst

--- a/chef_master/source/resources.rst
+++ b/chef_master/source/resources.rst
@@ -2994,10 +2994,6 @@ Properties
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 .. include:: ../../includes_resources/includes_resource_user_attributes.rst
 
-Supported Features
-+++++++++++++++++++++++++++++++++++++++++++++++++++++
-.. include:: ../../includes_resources/includes_resource_user_supported_features.rst
-
 Password Shadow Hash
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 .. include:: ../../includes_resources/includes_resource_user_password_shadow_hash.rst

--- a/includes_data_bag/includes_data_bag_recipes_create_users.rst
+++ b/includes_data_bag/includes_data_bag_recipes_create_users.rst
@@ -21,7 +21,7 @@ The |chef client| can create users on systems based on the contents of a data ba
        shell admin['shell']
        comment admin['comment']
        home homedir
-       supports :manage_home => true
+       manage_home true
      end
    
    end

--- a/includes_data_bag/includes_data_bag_search_example.rst
+++ b/includes_data_bag/includes_data_bag_search_example.rst
@@ -27,7 +27,7 @@ The following example shows how to use the search index to find all of the items
        comment admin['comment']
        
        home home
-       supports :manage_home => true
+       manage_home true
      end
    
    end

--- a/includes_resources/includes_resource_11-16_user_attributes.rst
+++ b/includes_resources/includes_resource_11-16_user_attributes.rst
@@ -87,11 +87,6 @@ This resource has the following properties:
 
    |subscribes timers|
 
-``supports``
-   **Ruby Type:** Hash
-
-   |supports user| Default value: ``:manage_home => false, :non_unique => false``.
-
 ``system``
    **Ruby Types:** TrueClass, FalseClass
 

--- a/includes_resources/includes_resource_11-16_user_syntax.rst
+++ b/includes_resources/includes_resource_11-16_user_syntax.rst
@@ -31,7 +31,6 @@ The full syntax for all of the properties that are available to the |resource us
      provider                   Chef::Provider::User
      shell                      String
      subscribes                 # see description
-     supports                   Hash
      system                     TrueClass, FalseClass
      uid                        String, Integer
      username                   String # defaults to 'name' if not specified
@@ -43,4 +42,4 @@ where
 * ``user`` is the resource
 * ``name`` is the name of the resource block
 * ``:action`` identifies the steps the |chef client| will take to bring the node into the desired state
-* ``comment``, ``force``, ``gid``, ``home``, ``manage_home``, ``non_unique``, ``password``, ``provider``, ``shell``, ``supports``, ``system``, ``uid``, and ``username`` are properties of this resource, with the |ruby| type shown. |see attributes|
+* ``comment``, ``force``, ``gid``, ``home``, ``manage_home``, ``non_unique``, ``password``, ``provider``, ``shell``, ``system``, ``uid``, and ``username`` are properties of this resource, with the |ruby| type shown. |see attributes|

--- a/includes_resources/includes_resource_user_attributes.rst
+++ b/includes_resources/includes_resource_user_attributes.rst
@@ -93,11 +93,6 @@ This resource has the following properties:
 
    |shell|
 
-``supports``
-   **Ruby Type:** Hash
-
-   |supports user| Default value: ``:manage_home => false, :non_unique => false``.
-
 ``subscribes``
    **Ruby Type:** Symbol, 'Chef::Resource[String]'
 

--- a/includes_resources/includes_resource_user_supported_features.rst
+++ b/includes_resources/includes_resource_user_supported_features.rst
@@ -1,10 +1,6 @@
 .. The contents of this file may be included in multiple topics (using the includes directive).
 .. The contents of this file should be modified in a way that preserves its ability to appear in multiple topics.
 
+The ``supports`` attribute of the ``user`` resource has been deprecated.  The ``supports[:manage_home]`` property was an alias
+for the ``manage_home`` property, while the ``supports[:non_unique]`` property was an alias for the ``non_unique`` property.
 
-The ``supports`` attribute allows a list of supported features to be identified. There are two features of note:
-
-* ``:manage_home`` indicates whether a user's home directory will be created when the user is created. When the ``Useradd`` provider is used, ``-dm`` wil be passed to ``useradd`` (when the ``:create`` action is used) and ``-d`` will be passed to ``usermod`` (when the ``:manage`` or ``:modify`` actions are used). If ``supports :manage_home=>true``, the |resource user| resource passes the ``-d`` and ``-m`` parameters together (i.e. ``-dm``) to ``usermod``.
-
-  When the ``Windows`` provider is used, |windows| does not create a home directory for a user until that user logs on for the first time; specifying the home directory does not have any effect as to where |windows| ultimately places the home directory.
-* ``:non_unique`` indicates whether non-unique UIDs are allowed. This option is currently unused by the existing providers.

--- a/includes_resources/includes_resource_user_syntax.rst
+++ b/includes_resources/includes_resource_user_syntax.rst
@@ -32,7 +32,6 @@ The full syntax for all of the properties that are available to the |resource us
      provider                   Chef::Provider::User
      salt                       String
      shell                      String
-     supports                   Hash
      subscribes                 # see description
      system                     TrueClass, FalseClass
      uid                        String, Integer
@@ -45,4 +44,4 @@ where
 * ``user`` is the resource
 * ``name`` is the name of the resource block
 * ``:action`` identifies the steps the |chef client| will take to bring the node into the desired state
-* ``comment``, ``force``, ``gid``, ``home``, ``iterations``, ``manage_home``, ``non_unique``, ``password``, ``provider``, ``salt``, ``shell``, ``supports``, ``system``, ``uid``, and ``username`` are properties of this resource, with the |ruby| type shown. |see attributes|
+* ``comment``, ``force``, ``gid``, ``home``, ``iterations``, ``manage_home``, ``non_unique``, ``password``, ``provider``, ``salt``, ``shell``, ``system``, ``uid``, and ``username`` are properties of this resource, with the |ruby| type shown. |see attributes|

--- a/includes_search/includes_search_data_bag.rst
+++ b/includes_search/includes_search_data_bag.rst
@@ -64,7 +64,7 @@ The following recipe can be used to create a user for each administrator by load
        shell     admin['shell']
        comment   admin['comment'] 
        home      home
-       supports  :manage_home => true
+       manage_home true
      end
 
    end
@@ -89,7 +89,7 @@ And then the same recipe, modified to load administrators using a search query (
        comment   admin['comment']
     
        home      home
-       supports  :manage_home => true
+       manage_home true
      end
     
    end

--- a/includes_slides/includes_slides_resources_type_user.rst
+++ b/includes_slides/includes_slides_resources_type_user.rst
@@ -10,5 +10,5 @@ A user that should be managed:
      comment 'Nginx <nginx@example.com>'
      uid '500'
      gid '500'
-     supports :manage_home => true
+     manage_home true
    end

--- a/release_chef_11-0/source/resource_user.rst
+++ b/release_chef_11-0/source/resource_user.rst
@@ -18,10 +18,6 @@ Properties
 =====================================================
 .. include:: ../../includes_resources/includes_resource_11-16_user_attributes.rst
 
-Supported Features
-=====================================================
-.. include:: ../../includes_resources/includes_resource_user_supported_features.rst
-
 Password Shadow Hash
 =====================================================
 .. include:: ../../includes_resources/includes_resource_user_password_shadow_hash.rst

--- a/release_chef_11-10/source/resource_user.rst
+++ b/release_chef_11-10/source/resource_user.rst
@@ -18,10 +18,6 @@ Properties
 =====================================================
 .. include:: ../../includes_resources/includes_resource_11-16_user_attributes.rst
 
-Supported Features
-=====================================================
-.. include:: ../../includes_resources/includes_resource_user_supported_features.rst
-
 Password Shadow Hash
 =====================================================
 .. include:: ../../includes_resources/includes_resource_user_password_shadow_hash.rst

--- a/release_chef_11-12/source/resource_user.rst
+++ b/release_chef_11-12/source/resource_user.rst
@@ -18,10 +18,6 @@ Properties
 =====================================================
 .. include:: ../../includes_resources/includes_resource_11-16_user_attributes.rst
 
-Supported Features
-=====================================================
-.. include:: ../../includes_resources/includes_resource_user_supported_features.rst
-
 Password Shadow Hash
 =====================================================
 .. include:: ../../includes_resources/includes_resource_user_password_shadow_hash.rst

--- a/release_chef_11-14/source/resource_user.rst
+++ b/release_chef_11-14/source/resource_user.rst
@@ -18,10 +18,6 @@ Properties
 =====================================================
 .. include:: ../../includes_resources/includes_resource_11-16_user_attributes.rst
 
-Supported Features
-=====================================================
-.. include:: ../../includes_resources/includes_resource_user_supported_features.rst
-
 Password Shadow Hash
 =====================================================
 .. include:: ../../includes_resources/includes_resource_user_password_shadow_hash.rst

--- a/release_chef_11-16/source/resource_user.rst
+++ b/release_chef_11-16/source/resource_user.rst
@@ -18,10 +18,6 @@ Properties
 =====================================================
 .. include:: ../../includes_resources/includes_resource_11-16_user_attributes.rst
 
-Supported Features
-=====================================================
-.. include:: ../../includes_resources/includes_resource_user_supported_features.rst
-
 Password Shadow Hash
 =====================================================
 .. include:: ../../includes_resources/includes_resource_user_password_shadow_hash.rst

--- a/release_chef_11-18/source/resource_user.rst
+++ b/release_chef_11-18/source/resource_user.rst
@@ -18,10 +18,6 @@ Properties
 =====================================================
 .. include:: ../../includes_resources/includes_resource_11-16_user_attributes.rst
 
-Supported Features
-=====================================================
-.. include:: ../../includes_resources/includes_resource_user_supported_features.rst
-
 Password Shadow Hash
 =====================================================
 .. include:: ../../includes_resources/includes_resource_user_password_shadow_hash.rst

--- a/release_chef_11-2/source/resource_user.rst
+++ b/release_chef_11-2/source/resource_user.rst
@@ -18,10 +18,6 @@ Properties
 =====================================================
 .. include:: ../../includes_resources/includes_resource_11-16_user_attributes.rst
 
-Supported Features
-=====================================================
-.. include:: ../../includes_resources/includes_resource_user_supported_features.rst
-
 Password Shadow Hash
 =====================================================
 .. include:: ../../includes_resources/includes_resource_user_password_shadow_hash.rst

--- a/release_chef_11-4/source/resource_user.rst
+++ b/release_chef_11-4/source/resource_user.rst
@@ -18,10 +18,6 @@ Properties
 =====================================================
 .. include:: ../../includes_resources/includes_resource_11-16_user_attributes.rst
 
-Supported Features
-=====================================================
-.. include:: ../../includes_resources/includes_resource_user_supported_features.rst
-
 Password Shadow Hash
 =====================================================
 .. include:: ../../includes_resources/includes_resource_user_password_shadow_hash.rst

--- a/release_chef_11-6/source/resource_user.rst
+++ b/release_chef_11-6/source/resource_user.rst
@@ -18,10 +18,6 @@ Properties
 =====================================================
 .. include:: ../../includes_resources/includes_resource_11-16_user_attributes.rst
 
-Supported Features
-=====================================================
-.. include:: ../../includes_resources/includes_resource_user_supported_features.rst
-
 Password Shadow Hash
 =====================================================
 .. include:: ../../includes_resources/includes_resource_user_password_shadow_hash.rst

--- a/release_chef_11-8/source/resource_user.rst
+++ b/release_chef_11-8/source/resource_user.rst
@@ -18,10 +18,6 @@ Properties
 =====================================================
 .. include:: ../../includes_resources/includes_resource_11-16_user_attributes.rst
 
-Supported Features
-=====================================================
-.. include:: ../../includes_resources/includes_resource_user_supported_features.rst
-
 Password Shadow Hash
 =====================================================
 .. include:: ../../includes_resources/includes_resource_user_password_shadow_hash.rst

--- a/step_resource/step_resource_user_create_random.rst
+++ b/step_resource/step_resource_user_create_random.rst
@@ -6,7 +6,7 @@
 .. code-block:: ruby
 
    user 'random' do
-     supports :manage_home => true
+     manage_home true
      comment 'User Random'
      uid '1234'
      gid '1234'


### PR DESCRIPTION
these are deprecated and never did what people thought they did
and everyone should have been using `manage_home` and `non_unique`
directly all along the whole time.

Signed-off-by: Lamont Granquist lamont@scriptkiddie.org
